### PR TITLE
vite-plugin-checker-vls should use default export as other plugins do

### DIFF
--- a/packages/checker-vls/src/main.ts
+++ b/packages/checker-vls/src/main.ts
@@ -69,5 +69,5 @@ declare const VlsChecker: (
   options?: VlsConfig
 ) => (config: VlsConfig & SharedConfig) => ServeAndBuildChecker
 
-export { VlsChecker }
+export default VlsChecker
 export type { VlsConfig }


### PR DESCRIPTION
As mention in `vite-plugin-checker` readme, `vite-plugin-checker-vls` should have a default export

```js
import VlsChecker from 'vite-plugin-checker-vls'
```