### PR TITLE
Add chalk dependency

### DIFF
--- a/packages/vite-plugin-checker/package.json
+++ b/packages/vite-plugin-checker/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@babel/code-frame": "^7.12.13",
     "ansi-escapes": "^4.3.0",
+    "chalk": "^4.1.1",
     "chokidar": "^3.5.1",
     "commander": "^8.0.0",
     "fast-glob": "^3.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,7 @@ importers:
       '@types/lodash.debounce': ^4.0.6
       '@types/lodash.pick': ^4.4.6
       ansi-escapes: ^4.3.0
+      chalk: ^4.1.1
       chokidar: ^3.5.1
       commander: ^8.0.0
       fast-glob: ^3.2.7
@@ -95,6 +96,7 @@ importers:
     dependencies:
       '@babel/code-frame': 7.12.13
       ansi-escapes: 4.3.2
+      chalk: 4.1.1
       chokidar: 3.5.1
       commander: 8.0.0
       fast-glob: 3.2.7
@@ -1616,7 +1618,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
-    dev: true
 
   /ansi-styles/5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
@@ -2320,7 +2321,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-    dev: true
 
   /char-regex/1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -2400,14 +2400,12 @@ packages:
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
-    dev: true
 
   /color-name/1.1.3:
     resolution: {integrity: sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=}
 
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-    dev: true
 
   /colorette/1.2.2:
     resolution: {integrity: sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==}
@@ -3504,7 +3502,6 @@ packages:
   /has-flag/4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /has/1.0.3:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
@@ -5997,7 +5994,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
-    dev: true
 
   /supports-color/8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}


### PR DESCRIPTION
`vite-plugin-checker` is missing its [chalk dependency](https://github.com/fi3ework/vite-plugin-checker/blob/257358fcd9b1ad28d9570c737d335225d8f60296/packages/vite-plugin-checker/src/logger.ts#L1). When using the plugin using Yarn PnP, it was complaining about that.