### PR TITLE
feat(vls): watch js/ts/json changed

### DIFF
--- a/packages/vite-plugin-checker/src/Checker.ts
+++ b/packages/vite-plugin-checker/src/Checker.ts
@@ -1,9 +1,10 @@
+import chokidar from 'chokidar'
 import invariant from 'tiny-invariant'
 import { isMainThread } from 'worker_threads'
 
-import { ServeAndBuildChecker, BuildInCheckerNames } from './types'
+import { NormalizedDiagnostic } from './logger'
+import { BuildInCheckerNames, ServeAndBuildChecker } from './types'
 import { createScript, Script } from './worker'
-import chokidar from 'chokidar'
 
 // still an only issue https://github.com/microsoft/TypeScript/issues/29808#issuecomment-829750974
 import type {} from 'vite'
@@ -14,7 +15,7 @@ if (!isMainThread) {
 }
 
 export interface CheckerMeta<T extends BuildInCheckerNames> {
-  name: string
+  name: T
   absFilePath: string
   createDiagnostic: CreateDiagnostic<T>
   build: ServeAndBuildChecker['build']
@@ -26,7 +27,7 @@ export abstract class Checker<T extends BuildInCheckerNames> implements CheckerM
     ignored: (path: string) => path.includes('node_modules'),
   })
 
-  public name: string
+  public name: T
   public absFilePath: string
   public createDiagnostic: CreateDiagnostic<T>
   public build: ServeAndBuildChecker['build']
@@ -37,7 +38,6 @@ export abstract class Checker<T extends BuildInCheckerNames> implements CheckerM
     this.absFilePath = absFilePath
     this.build = build
     this.createDiagnostic = createDiagnostic
-    this.build = build
   }
 
   public prepare() {

--- a/packages/vite-plugin-checker/src/DiagnosticCache.ts
+++ b/packages/vite-plugin-checker/src/DiagnosticCache.ts
@@ -1,0 +1,38 @@
+import type { NormalizedDiagnostic } from './logger'
+
+class DiagnosticCache {
+  public diagnostics: NormalizedDiagnostic[] = []
+
+  public get(fileName?: string) {
+    if (fileName) {
+      return this.diagnostics.filter((f) => f.id === fileName)
+    }
+
+    return this.diagnostics
+  }
+
+  public initWith(diagnostics: NormalizedDiagnostic[]) {
+    diagnostics.forEach((d) => {
+      this.diagnostics.push(d)
+    })
+  }
+
+  public get last() {
+    return this.diagnostics[this.diagnostics.length - 1]
+  }
+
+  public set(fileName: string, next: NormalizedDiagnostic[] | null) {
+    for (let i = 0; i < this.diagnostics.length; i++) {
+      if (this.diagnostics[i].id === fileName) {
+        this.diagnostics.splice(i, 1)
+        i--
+      }
+    }
+
+    if (next?.length) {
+      this.diagnostics.push(...next)
+    }
+  }
+}
+
+export { DiagnosticCache }

--- a/packages/vite-plugin-checker/src/checkers/vueTsc/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/vueTsc/main.ts
@@ -17,7 +17,7 @@ const createDiagnostic: CreateDiagnostic<'vueTsc'> = (pluginConfig) => {
 export class VueTscChecker extends Checker<'vueTsc'> {
   public constructor() {
     super({
-      name: 'typescript',
+      name: 'vueTsc',
       absFilePath: __filename,
       build: { buildBin: ['vue-tsc', ['--noEmit']] },
       createDiagnostic,

--- a/packages/vite-plugin-checker/src/main.ts
+++ b/packages/vite-plugin-checker/src/main.ts
@@ -3,7 +3,7 @@ import pick from 'lodash.pick'
 import npmRunPath from 'npm-run-path'
 import os from 'os'
 import { ConfigEnv, Plugin } from 'vite'
-
+// 
 import type {
   OverlayErrorAction,
   BuildInCheckerNames,

--- a/playground/vue2-vls/src/store/index.ts
+++ b/playground/vue2-vls/src/store/index.ts
@@ -3,6 +3,10 @@ import Vuex from 'vuex'
 
 Vue.use(Vuex)
 
+export interface IProps {
+  count: number
+}
+
 export default new Vuex.Store({
   state: {},
   mutations: {},

--- a/playground/vue2-vls/src/views/Home.vue
+++ b/playground/vue2-vls/src/views/Home.vue
@@ -6,5 +6,17 @@
 </template>
 
 <script lang="ts">
-export default {}
+import Vuex from 'vuex'
+import Vue from 'vue'
+// import { IProps } from '../store/index'
+
+Vue.use(Vuex)
+
+export default {
+  computed: {
+    supply() {
+      return this.$store.state.count
+    },
+  },
+}
 </script>


### PR DESCRIPTION
- [ ] should clean messy log 
![image](https://user-images.githubusercontent.com/12322740/128640723-e40e1018-13ff-4639-8d26-71ff27f0837c.png)
- [ ] should add diagnostic cache for `.vue` file as the un-edited which has error will be flushed by other edited `.vue` file.