### PR TITLE
feat(eslint): allow specifying eslint config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ _coming soon._
 | :--------- | -------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | files      | `string \| string[]` | This value is required | The lint target files. This can contain any of file paths, directory paths, and glob patterns. ([Details](https://eslint.org/docs/developer-guide/nodejs-api#parameters-1)).            |
 | extensions | `string[]`           | `['.js']`              | Specify linted file extensions, 'extensions' must be an array of non-empty strings, e.g. `['.jsx', '.js']`. ([Details](https://eslint.org/docs/developer-guide/nodejs-api#parameters)). |
+| configPath | `string`             |                        | Specify path to ESLint config file, if you wish to override ESLint's default configuration discovery.                                                                                   |
 
 ## Playground
 

--- a/packages/vite-plugin-checker/src/checkers/eslint/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/eslint/main.ts
@@ -30,9 +30,13 @@ const createDiagnostic: CreateDiagnostic<'eslint'> = (pluginConfig) => {
       if (!pluginConfig.eslint) return
 
       const extensions = pluginConfig.eslint.extensions ?? ['.js']
+      const overrideConfigFile = pluginConfig.eslint.configPath
+        ? { overrideConfigFile: pluginConfig.eslint.configPath }
+        : {}
       const eslint = new ESLint({
         cwd: root,
         extensions,
+        ...overrideConfigFile,
       })
       invariant(pluginConfig.eslint, 'config.eslint should not be `false`')
       invariant(
@@ -111,15 +115,19 @@ export class EslintChecker extends Checker<'eslint'> {
         buildBin: (pluginConfig) => {
           let ext = ['.js']
           let files: string[] = []
+          let overrideConfigFile: string[] = []
           if (pluginConfig.eslint) {
             ext = pluginConfig.eslint.extensions ?? ext
             files =
               typeof pluginConfig.eslint.files === 'string'
                 ? [pluginConfig.eslint.files]
                 : pluginConfig.eslint.files
+            overrideConfigFile = pluginConfig.eslint.configPath
+              ? ['--config', pluginConfig.eslint.configPath]
+              : []
           }
 
-          return ['eslint', ['--ext', ext.join(','), ...files]]
+          return ['eslint', ['--ext', ext.join(','), ...overrideConfigFile, ...files]]
         },
       },
       createDiagnostic,

--- a/packages/vite-plugin-checker/src/types.ts
+++ b/packages/vite-plugin-checker/src/types.ts
@@ -43,6 +43,10 @@ export type EslintConfig =
        * @defaultValue: 300
        */
       // watchDelay?: number
+      /**
+       * Specify path to ESLint config file, if you wish to override ESLint's default configuration discovery.
+       */
+      configPath?: string
     }
 
 /** checkers shared configuration */


### PR DESCRIPTION
Add configuration option to pass through to ESLint that will specify a custom path for ESLint to find the configuration file to be used.

This is useful in our situation (legacy project with multiple builds + eslints in the mix) when the root eslintrc file is incorrect for the code that Vite is building. New code is separated in a pseudo monorepo structure so we need to be able to point at a different base eslintrc config file.