### PR TITLE
Add support for tsc build option in watch mode

### DIFF
--- a/packages/vite-plugin-checker/src/checkers/typescript/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/typescript/main.ts
@@ -102,16 +102,22 @@ const createDiagnostic: CreateDiagnostic<'typescript'> = (pluginConfig) => {
       // https://github.com/microsoft/TypeScript/pull/33082/files
       const createProgram = ts.createEmitAndSemanticDiagnosticsBuilderProgram
 
-      const host = ts.createWatchCompilerHost(
-        configFile,
-        { noEmit: true },
-        ts.sys,
-        createProgram,
-        reportDiagnostic,
-        reportWatchStatusChanged
-      )
+      if (typeof pluginConfig.typescript === 'object' &&  pluginConfig.typescript.buildMode) {
+        const host = ts.createSolutionBuilderWithWatchHost(ts.sys, createProgram, reportDiagnostic, undefined, reportWatchStatusChanged)
 
-      ts.createWatchProgram(host)
+        ts.createSolutionBuilderWithWatch(host, [configFile], {}).build()
+      } else {
+        const host = ts.createWatchCompilerHost(
+          configFile,
+          { noEmit: true },
+          ts.sys,
+          createProgram,
+          reportDiagnostic,
+          reportWatchStatusChanged
+        )
+  
+        ts.createWatchProgram(host)
+      }
     },
   }
 }


### PR DESCRIPTION
The buildMode flag works great when building project but it is not taken into account when watching (ts errors happening on root project are shown but tsc does not check referenced projects). 

This commit fixes this by using TS Compiler API SolutionBuilder when buildMode is set to true.