### PR TITLE
Add support for passing configuration to VLS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,12 +149,13 @@ export default {
 
 ### config.vls
 
-VLS configuration accepts the same values that can be configured in VS code with keys that start with `vetur`. 
-These are configured with nested objects rather than dotted string notation. Typescript intellisense is available. 
+VLS configuration accepts the same values that can be configured in VS code with keys that start with `vetur`.
+These are configured with nested objects rather than dotted string notation. TypeScript intellisense is available.
 
 See [`initParams.ts`](https://github.com/fi3ework/vite-plugin-checker/blob/8fc5d7f4a908a4c80d1cb978e0acf1d4e5700e6a/packages/vite-plugin-checker/src/checkers/vls/initParams.ts#L33) for a comprehensive list of the defaults that can be overridden. Vetur unfortunately does not provide a single comprehensive document of all its options.
 
 For example, to performing checking only the `<script>` block:
+
 ```ts
 checker({
   vls: {

--- a/README.md
+++ b/README.md
@@ -149,11 +149,26 @@ export default {
 
 ### config.vls
 
-_coming soon._
+VLS configuration accepts the same values that can be configured in VS code with keys that start with `vetur`. 
+These are configured with nested objects rather than dotted string notation. Typescript intellisense is available. 
 
-| field | Type | Default value | Description |
-| :---- | ---- | ------------- | ----------- |
-|       |      |               |             |
+See [`initParams.ts`](https://github.com/fi3ework/vite-plugin-checker/blob/8fc5d7f4a908a4c80d1cb978e0acf1d4e5700e6a/packages/vite-plugin-checker/src/checkers/vls/initParams.ts#L33) for a comprehensive list of the defaults that can be overridden. Vetur unfortunately does not provide a single comprehensive document of all its options.
+
+For example, to performing checking only the `<script>` block:
+```ts
+checker({
+  vls: {
+    vetur: {
+      validation: {
+        template: false,
+        templateProps: false,
+        interpolation: false,
+        style: false,
+      },
+    },
+  },
+}),
+```
 
 ### config.vueTsc
 

--- a/packages/vite-plugin-checker/src/checkers/vls/cli.ts
+++ b/packages/vite-plugin-checker/src/checkers/vls/cli.ts
@@ -23,8 +23,9 @@ function validateLogLevel(logLevelInput: unknown): logLevelInput is LogLevel {
     .command('diagnostics [workspace]')
     .description('Print all diagnostics')
     .addOption(
-      new Option('-c, --checker-config <checkerConfig>', 'Option overrides to pass to VTI')
-        .default('{}')
+      new Option('-c, --checker-config <checkerConfig>', 'Option overrides to pass to VTI').default(
+        '{}'
+      )
     )
     .addOption(
       new Option('-l, --log-level <logLevel>', 'Log level to print')
@@ -39,14 +40,18 @@ function validateLogLevel(logLevelInput: unknown): logLevelInput is LogLevel {
         throw new Error(`Invalid log level: ${logLevelOption}`)
       }
 
-      let parsedConfig;
+      let parsedConfig
       try {
         parsedConfig = JSON.parse(options.checkerConfig) as any
       } catch {
         throw new Error(`Unable to parse checker-config JSON: ${options.checkerConfig}`)
       }
 
-      await diagnostics(workspace, logLevelOption, { watch: false, verbose: false, config: parsedConfig })
+      await diagnostics(workspace, logLevelOption, {
+        watch: false,
+        verbose: false,
+        config: parsedConfig,
+      })
     })
 
   program.parse(process.argv)

--- a/packages/vite-plugin-checker/src/checkers/vls/cli.ts
+++ b/packages/vite-plugin-checker/src/checkers/vls/cli.ts
@@ -23,6 +23,10 @@ function validateLogLevel(logLevelInput: unknown): logLevelInput is LogLevel {
     .command('diagnostics [workspace]')
     .description('Print all diagnostics')
     .addOption(
+      new Option('-c, --checker-config <checkerConfig>', 'Option overrides to pass to VTI')
+        .default('{}')
+    )
+    .addOption(
       new Option('-l, --log-level <logLevel>', 'Log level to print')
         .default('WARN')
         // logLevels is readonly array but .choices need read-write array (because of weak typing)
@@ -35,7 +39,14 @@ function validateLogLevel(logLevelInput: unknown): logLevelInput is LogLevel {
         throw new Error(`Invalid log level: ${logLevelOption}`)
       }
 
-      await diagnostics(workspace, logLevelOption)
+      let parsedConfig;
+      try {
+        parsedConfig = JSON.parse(options.checkerConfig) as any
+      } catch {
+        throw new Error(`Unable to parse checker-config JSON: ${options.checkerConfig}`)
+      }
+
+      await diagnostics(workspace, logLevelOption, { watch: false, verbose: false, config: parsedConfig })
     })
 
   program.parse(process.argv)

--- a/packages/vite-plugin-checker/src/checkers/vls/diagnostics.ts
+++ b/packages/vite-plugin-checker/src/checkers/vls/diagnostics.ts
@@ -204,7 +204,7 @@ async function prepareClientConnection(workspaceUri: URI, options: DiagnosticOpt
 
   if (options.config) {
     // Merge in used-provided VLS settings if present
-    mergeDeep(init.initializationOptions.config, options.config);
+    mergeDeep(init.initializationOptions.config, options.config)
   }
 
   await clientConnection.sendRequest(InitializeRequest.type, init)
@@ -323,22 +323,21 @@ async function getDiagnostics(
   return initialErrCount
 }
 
-
 function isObject(item: any): item is {} {
-  return item && typeof item === 'object' && !Array.isArray(item);
+  return item && typeof item === 'object' && !Array.isArray(item)
 }
 
 function mergeDeep<T>(target: T, source: DeepPartial<T> | undefined) {
   if (isObject(target) && isObject(source)) {
     for (const key in source) {
       if (isObject(source[key])) {
-        if (!target[key]) Object.assign(target, { [key]: {} });
-        mergeDeep(target[key], source[key]);
+        if (!target[key]) Object.assign(target, { [key]: {} })
+        mergeDeep(target[key], source[key])
       } else {
-        Object.assign(target, { [key]: source[key] });
+        Object.assign(target, { [key]: source[key] })
       }
     }
   }
 
-  return target;
+  return target
 }

--- a/packages/vite-plugin-checker/src/checkers/vls/initParams.ts
+++ b/packages/vite-plugin-checker/src/checkers/vls/initParams.ts
@@ -2,7 +2,7 @@ import { URI } from 'vscode-uri'
 
 import type { InitializeParams } from 'vscode-languageserver/node'
 
-export type VlsOptions = ReturnType<typeof getDefaultVLSConfig>;
+export type VlsOptions = ReturnType<typeof getDefaultVLSConfig>
 
 export function getInitParams(workspaceUri: URI): InitializeParams {
   const defaultVLSConfig = getDefaultVLSConfig()

--- a/packages/vite-plugin-checker/src/checkers/vls/initParams.ts
+++ b/packages/vite-plugin-checker/src/checkers/vls/initParams.ts
@@ -2,6 +2,8 @@ import { URI } from 'vscode-uri'
 
 import type { InitializeParams } from 'vscode-languageserver/node'
 
+export type VlsOptions = ReturnType<typeof getDefaultVLSConfig>;
+
 export function getInitParams(workspaceUri: URI): InitializeParams {
   const defaultVLSConfig = getDefaultVLSConfig()
 

--- a/packages/vite-plugin-checker/src/main.ts
+++ b/packages/vite-plugin-checker/src/main.ts
@@ -152,8 +152,8 @@ function spawnChecker(
       // Command line args constructed by checkers therefore need to escape double quotes
       // to have them not striped out by cmd.exe. Using shell on all platforms lets us avoid
       // having to perform platform-specific logic around escaping quotes since all platform
-      // shells will strip out unescaped double quotes. shell=false on linux would result
-      // on escaped quotes not being unescaped.
+      // shells will strip out unescaped double quotes. E.g. shell=false on linux only would 
+      // result in escaped quotes not being unescaped.
       shell: true,
     })
 

--- a/packages/vite-plugin-checker/src/main.ts
+++ b/packages/vite-plugin-checker/src/main.ts
@@ -152,7 +152,7 @@ function spawnChecker(
       // Command line args constructed by checkers therefore need to escape double quotes
       // to have them not striped out by cmd.exe. Using shell on all platforms lets us avoid
       // having to perform platform-specific logic around escaping quotes since all platform
-      // shells will strip out unescaped double quotes. E.g. shell=false on linux only would 
+      // shells will strip out unescaped double quotes. E.g. shell=false on linux only would
       // result in escaped quotes not being unescaped.
       shell: true,
     })

--- a/packages/vite-plugin-checker/src/main.ts
+++ b/packages/vite-plugin-checker/src/main.ts
@@ -148,7 +148,13 @@ function spawnChecker(
       cwd: process.cwd(),
       stdio: 'inherit',
       env: localEnv,
-      shell: os.platform() === 'win32',
+      // shell is necessary on windows to get the process to even start.
+      // Command line args constructed by checkers therefore need to escape double quotes
+      // to have them not striped out by cmd.exe. Using shell on all platforms lets us avoid
+      // having to perform platform-specific logic around escaping quotes since all platform
+      // shells will strip out unescaped double quotes. shell=false on linux would result
+      // on escaped quotes not being unescaped.
+      shell: true,
     })
 
     proc.on('exit', (code) => {

--- a/packages/vite-plugin-checker/src/types.ts
+++ b/packages/vite-plugin-checker/src/types.ts
@@ -1,6 +1,7 @@
 import type { HMRPayload, ServerOptions, ConfigEnv } from 'vite'
 import type { Worker } from 'worker_threads'
 import type { ESLint } from 'eslint'
+import type { VlsOptions } from './checkers/vls/initParams'
 
 /* ----------------------------- userland plugin options ----------------------------- */
 
@@ -24,11 +25,7 @@ export type VueTscConfig =
     }>
 
 /** vls checker configuration */
-export type VlsConfig =
-  | boolean
-  | Partial<{
-      // TODO: support vls config
-    }>
+export type VlsConfig = boolean | DeepPartial<VlsOptions>
 
 /** ESLint checker configuration */
 export type EslintConfig =
@@ -179,3 +176,9 @@ export interface CheckerDiagnostic {
 export type CreateDiagnostic<T extends BuildInCheckerNames = any> = (
   config: Pick<BuildInCheckers, T> & SharedConfig
 ) => CheckerDiagnostic
+
+/* ----------------------------- generic utility types ----------------------------- */
+
+export type DeepPartial<T> = {
+  [P in keyof T]?: DeepPartial<T[P]>
+}


### PR DESCRIPTION
Adds support for configuring VLS. All VLS configuration (that which is defined in `getDefaultVLSConfig`) is candidates for customization. Configuration is passed via CLI arguments in build mode, and by `workerData` in serve mode.

Tested on Windows 10 and Ubuntu 18.04 (via WSL).

Fixes #85.