### PR TITLE
Make log level filters respected in serve/watch mode with VLS.

### DIFF
--- a/packages/vite-plugin-checker/__tests__/unit/vlsConfig.spec.ts
+++ b/packages/vite-plugin-checker/__tests__/unit/vlsConfig.spec.ts
@@ -1,13 +1,13 @@
 import path from 'path'
-import { ShutdownRequest } from 'vscode-languageserver/node'
+import { ShutdownRequest, DiagnosticSeverity } from 'vscode-languageserver/node'
 import { URI } from 'vscode-uri'
 
-import { prepareClientConnection } from '../../src/checkers/vls/diagnostics'
+import { prepareClientConnection, logLevel2Severity } from '../../src/checkers/vls/diagnostics'
 
 async function testVslConfig(overrideConfig?: any) {
   const workspaceUri = URI.file(path.join(__dirname, 'fixtures'))
   const { clientConnection, serverConnection, vls, up, down, logger } =
-    await prepareClientConnection(workspaceUri, {
+    await prepareClientConnection(workspaceUri, logLevel2Severity['WARN'], {
       watch: false,
       verbose: false,
       config: overrideConfig || null,

--- a/packages/vite-plugin-checker/src/checkers/vls/diagnostics.ts
+++ b/packages/vite-plugin-checker/src/checkers/vls/diagnostics.ts
@@ -46,7 +46,7 @@ export const logLevels = ['ERROR', 'WARN', 'INFO', 'HINT'] as const
 
 let disposeSuppressConsole: ReturnType<typeof suppressConsole>
 
-const logLevel2Severity = {
+export const logLevel2Severity = {
   ERROR: DiagnosticSeverity.Error,
   WARN: DiagnosticSeverity.Warning,
   INFO: DiagnosticSeverity.Information,

--- a/packages/vite-plugin-checker/src/checkers/vls/diagnostics.ts
+++ b/packages/vite-plugin-checker/src/checkers/vls/diagnostics.ts
@@ -160,6 +160,8 @@ export async function prepareClientConnection(
       return
     }
 
+    publishDiagnostics.diagnostics = filterDiagnostics(publishDiagnostics.diagnostics, severity)
+
     if (!publishDiagnostics.diagnostics.length) {
       return
     }


### PR DESCRIPTION
A partial fix for #63.

Suggestions will no longer be logged or overlayed in serve mode. Warnings and errors still are.