### PR TITLE
fix: DataCloneError at worker.postMessage

### DIFF
--- a/packages/vite-plugin-checker/src/main.ts
+++ b/packages/vite-plugin-checker/src/main.ts
@@ -51,10 +51,11 @@ export default function Plugin(userConfig: UserPluginConfig): Plugin {
       checkers = createCheckers(userConfig || {}, env)
       if (viteMode !== 'serve') return
 
+      const hmr = config.server?.hmr
       checkers.forEach((checker) => {
         const workerConfig = checker.serve.config
         workerConfig({
-          hmr: config.server?.hmr,
+          hmr: typeof hmr === 'object' ? { overlay: hmr.overlay } : hmr,
           env,
         })
       })

--- a/packages/vite-plugin-checker/src/types.ts
+++ b/packages/vite-plugin-checker/src/types.ts
@@ -1,4 +1,4 @@
-import type { HMRPayload, ServerOptions, ConfigEnv } from 'vite'
+import type { ConfigEnv, HMRPayload } from 'vite'
 import type { Worker } from 'worker_threads'
 
 /* ----------------------------- userland plugin options ----------------------------- */
@@ -106,7 +106,10 @@ export interface OverlayErrorAction extends Action {
 
 export interface ConfigAction extends Action {
   type: ACTION_TYPES.config
-  payload: Pick<ServerOptions, 'hmr'> & { env: ConfigEnv }
+  payload: {
+    hmr?: { overlay?: boolean } | boolean
+    env: ConfigEnv
+  }
 }
 
 export interface ConfigureServerAction extends Action {
@@ -150,7 +153,7 @@ export interface ServeChecker<T extends BuildInCheckerNames = any> {
 }
 
 export interface CheckerDiagnostic {
-  config: (options: Pick<ServerOptions, 'hmr'> & { env: ConfigEnv }) => unknown
+  config: (options: { hmr?: { overlay?: boolean } | boolean; env: ConfigEnv }) => unknown
   configureServer: (options: { root: string }) => unknown
 }
 


### PR DESCRIPTION
Hi, maintainers and contributors!
I love the plugin because it's handy and will protect our team from wrong types.

I found an issue and made this PR to fix it.
It would be nice that the PR is merged! 🙏 

# Issue

Passing options as objects to `server.hmr` raises DataCloneError.
I noticed this when using `storybook-builder-vite`.

```ts
// storybook-build-vite will pass a Server instance to `server.hmr.server` like:
export default defineConfig({
  // ...
  server: {
    hmr: {
      server: new http.Server(),
    },
  },
})
```

```console
error when starting dev server:
DataCloneError: function connectionListener(socket) {
  defaultTriggerAsyncIdScope(
    getOrSetAsyncId(socket), connectionList...<omitted>...
} could not be cloned.
    at Worker.postMessage (internal/worker.js:301:23)
    at config (/Users/kazuma/work/oss/vite-plugin-checker/packages/vite-plugin-checker/lib/worker.js:22:32)
    at /Users/kazuma/work/oss/vite-plugin-checker/packages/vite-plugin-checker/lib/main.js:62:17
    at Array.forEach (<anonymous>)
    at Object.config (/Users/kazuma/work/oss/vite-plugin-checker/packages/vite-plugin-checker/lib/main.js:59:22)
    at resolveConfig (/Users/kazuma/work/oss/vite-plugin-checker/node_modules/.pnpm/vite@2.3.8/node_modules/vite/dist/node/chunks/dep-0ed4fbc0.js:71622:33)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async createServer (/Users/kazuma/work/oss/vite-plugin-checker/node_modules/.pnpm/vite@2.3.8/node_modules/vite/dist/node/chunks/dep-0ed4fbc0.js:70142:20)
    at async CAC.<anonymous> (/Users/kazuma/work/oss/vite-plugin-checker/node_modules/.pnpm/vite@2.3.8/node_modules/vite/dist/node/cli.js:13892:24)
```

# Reproduction

Check out my `repro-data-clone-error` branch or modify `playground/react-ts/vite.config.ts` as the diff shows, and run `npm run dev` at `playground/react-ts`.

https://github.com/fi3ework/vite-plugin-checker/compare/main...kazuma1989:repro-data-clone-error

# Solution

This problem occurs because a checker is passing a `Server` instance to `worker.postMessage` that cannot be copied with the ["structured clone algorithm"](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).

However, even if you pass the value of `server` to the `hmr` option, it is not actually used.
So I changed it to pass only the necessary options.

https://github.com/fi3ework/vite-plugin-checker/blob/8fc5d7f4a908a4c80d1cb978e0acf1d4e5700e6a/packages/vite-plugin-checker/src/checkers/typescript/main.ts#L23-L29