### PR TITLE
feat: new ESLint config API

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,12 +165,10 @@ _coming soon._
 
 ### config.eslint
 
-| field       | Type                 | Default value          | Description                                                                                                                                                                             |
-| :---------- | -------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| files       | `string \| string[]` | This value is required | The lint target files. This can contain any of file paths, directory paths, and glob patterns. ([Details](https://eslint.org/docs/developer-guide/nodejs-api#parameters-1)).            |
-| extensions  | `string[]`           | `['.js']`              | Specify linted file extensions, 'extensions' must be an array of non-empty strings, e.g. `['.jsx', '.js']`. ([Details](https://eslint.org/docs/developer-guide/nodejs-api#parameters)). |
-| configFile  | `string`             | `undefined`            | Specify path to ESLint config file, if you wish to override ESLint's default configuration discovery. Equivalent to ESLint's "--config" option.                                         |
-| maxWarnings | `number`             | `undefined`            | Fail a build if there are more than this many warnings.                                                                                                                                 |
+| field               | Type                                                                                                       | Default value          | Description                                                                                                                                                                              |
+| :------------------ | ---------------------------------------------------------------------------------------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| lintCommand         | `string`                                                                                                   | This value is required | `lintCommand` will be executed at build mode, and will also be used as default config for dev mode when `eslint.devOptions.eslint` is nullable.                                          |
+| `devOptions.eslint` | [`ESLint.Options`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/eslint/index.d.ts) | `undefined`            | You can override the options of the translated from `lintCommand`. Config priority: `const eslint = new ESLint({cwd: root, ...translatedOptions, ...pluginConfig.eslint.devOptions, })`. |
 
 ## Playground
 

--- a/packages/vite-plugin-checker/package.json
+++ b/packages/vite-plugin-checker/package.json
@@ -55,6 +55,7 @@
     "@types/eslint": "^7.2.14",
     "@types/lodash.debounce": "^4.0.6",
     "@types/lodash.pick": "^4.4.6",
+    "optionator": "^0.9.1",
     "vls": "^0.7.2"
   }
 }

--- a/packages/vite-plugin-checker/src/checkers/eslint/cli.js
+++ b/packages/vite-plugin-checker/src/checkers/eslint/cli.js
@@ -1,0 +1,76 @@
+/* eslint-disable */
+
+// Copied from /eslint@7.28.0/node_modules/eslint/lib/cli.js
+
+function quietFixPredicate(message) {
+  return message.severity === 2
+}
+
+export function translateOptions({
+  cache,
+  cacheFile,
+  cacheLocation,
+  cacheStrategy,
+  config,
+  env,
+  errorOnUnmatchedPattern,
+  eslintrc,
+  ext,
+  fix,
+  fixDryRun,
+  fixType,
+  global,
+  ignore,
+  ignorePath,
+  ignorePattern,
+  inlineConfig,
+  parser,
+  parserOptions,
+  plugin,
+  quiet,
+  reportUnusedDisableDirectives,
+  resolvePluginsRelativeTo,
+  rule,
+  rulesdir,
+}) {
+  return {
+    allowInlineConfig: inlineConfig,
+    cache,
+    cacheLocation: cacheLocation || cacheFile,
+    cacheStrategy,
+    errorOnUnmatchedPattern,
+    extensions: ext,
+    fix: (fix || fixDryRun) && (quiet ? quietFixPredicate : true),
+    fixTypes: fixType,
+    ignore,
+    ignorePath,
+    overrideConfig: {
+      env:
+        env &&
+        env.reduce((obj, name) => {
+          obj[name] = true
+          return obj
+        }, {}),
+      globals:
+        global &&
+        global.reduce((obj, name) => {
+          if (name.endsWith(':true')) {
+            obj[name.slice(0, -5)] = 'writable'
+          } else {
+            obj[name] = 'readonly'
+          }
+          return obj
+        }, {}),
+      ignorePatterns: ignorePattern,
+      parser,
+      parserOptions,
+      plugins: plugin,
+      rules: rule,
+    },
+    overrideConfigFile: config,
+    reportUnusedDisableDirectives: reportUnusedDisableDirectives ? 'error' : void 0,
+    resolvePluginsRelativeTo,
+    rulePaths: rulesdir,
+    useEslintrc: eslintrc,
+  }
+}

--- a/packages/vite-plugin-checker/src/types.ts
+++ b/packages/vite-plugin-checker/src/types.ts
@@ -1,5 +1,6 @@
 import type { HMRPayload, ServerOptions, ConfigEnv } from 'vite'
 import type { Worker } from 'worker_threads'
+import type { ESLint } from 'eslint'
 
 /* ----------------------------- userland plugin options ----------------------------- */
 
@@ -33,28 +34,40 @@ export type VlsConfig =
 export type EslintConfig =
   | false
   | {
-      /** The lint target files. This can contain any of file paths, directory paths, and glob patterns. ([Details](https://eslint.org/docs/developer-guide/nodejs-api#parameters-1)). */
-      files: string | string[]
       /**
-       * Specify linted file extensions, 'extensions' must be an array of non-empty strings, e.g. `['.jsx', '.js']`. ([Details](https://eslint.org/docs/developer-guide/nodejs-api#parameters)).
-       * @defaultValue: ['.js']
+       * lintCommand will be executed at build mode, and will also be used as
+       * default config for dev mode when options.eslint.devOptions.eslint is nullable.
        */
-      extensions?: string[]
-      /**
-       * millisecond for watcher to wait to trigger re-lint
-       * @defaultValue: 300
-       */
-      // watchDelay?: number
-      /**
-       * Specify path to ESLint config file, if you wish to override ESLint's default configuration discovery.
-       * Equivalent to ESLint's "--config" option.
-       */
-      configFile?: string
-      /*
-       * Fail a build if there are more than this many warnings.
-       */
-      maxWarnings?: number
+      lintCommand: string
+      devOptions?: {
+        /** You can override the options of translated from lintCommand. */
+        eslint?: ESLint.Options
+      }
     }
+
+// {
+//     /** The lint target files. This can contain any of file paths, directory paths, and glob patterns. ([Details](https://eslint.org/docs/developer-guide/nodejs-api#parameters-1)). */
+//     files: string | string[]
+//     /**
+//      * Specify linted file extensions, 'extensions' must be an array of non-empty strings, e.g. `['.jsx', '.js']`. ([Details](https://eslint.org/docs/developer-guide/nodejs-api#parameters)).
+//      * @defaultValue: ['.js']
+//      */
+//     extensions?: string[]
+//     /**
+//      * millisecond for watcher to wait to trigger re-lint
+//      * @defaultValue: 300
+//      */
+//     // watchDelay?: number
+//     /**
+//      * Specify path to ESLint config file, if you wish to override ESLint's default configuration discovery.
+//      * Equivalent to ESLint's "--config" option.
+//      */
+//     configFile?: string
+//     /*
+//      * Fail a build if there are more than this many warnings.
+//      */
+//     maxWarnings?: number
+//   }
 
 /** checkers shared configuration */
 export interface SharedConfig {

--- a/playground/vanilla-ts/vite.config.ts
+++ b/playground/vanilla-ts/vite.config.ts
@@ -8,8 +8,7 @@ export default defineConfig({
     reactRefresh(),
     checker({
       eslint: {
-        files: ['./src'],
-        extensions: ['.ts'],
+        lintCommand: 'eslint ./src --ext .ts',
       },
     }),
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,7 @@ importers:
       lodash.debounce: ^4.0.8
       lodash.pick: ^4.4.0
       npm-run-path: ^4.0.1
+      optionator: ^0.9.1
       strip-ansi: ^6.0.0
       tiny-invariant: ^1.1.0
       vls: ^0.7.2
@@ -117,6 +118,7 @@ importers:
       '@types/eslint': 7.2.14
       '@types/lodash.debounce': 4.0.6
       '@types/lodash.pick': 4.4.6
+      optionator: 0.9.1
       vls: 0.7.4
 
   playground/react-ts:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowJs": true,
     "target": "ES2015",
     "lib": ["ESNext"],
     "module": "CommonJS",


### PR DESCRIPTION
BREAKING CHANGE: eslint configs is changed. We made it full configurable of ESLint and remove all the hard coding config properties in 0.3.x. Now, you are allowed to write lint command which you're more familar with rather than JS config.