### PR TITLE
Allow Vite 3 beta as peer dependency

### DIFF
--- a/packages/vite-plugin-checker/package.json
+++ b/packages/vite-plugin-checker/package.json
@@ -50,7 +50,7 @@
     "vscode-uri": "^3.0.2"
   },
   "peerDependencies": {
-    "vite": ">=2"
+    "vite": "^2.0.0 || ^3.0.0-0"
   },
   "devDependencies": {
     "@types/eslint": "^7.2.14",


### PR DESCRIPTION
Allows installing the beta versions of Vite 3 ([same range](https://github.com/vitest-dev/vitest/blob/c5d07b844504f78e25f33bf3cac5b12f52886de9/packages/vitest/package.json#L97) as Vitest). Prevents error messages when installing:

```log
npm ERR! Could not resolve dependency:
npm ERR! peer vite@">=2" from vite-plugin-checker@0.4.8
npm ERR! node_modules/vite-plugin-checker
npm ERR!   dev vite-plugin-checker@"^0.4.8" from the root project
```