### PR TITLE
Skip running ESLint on ignored files

### DIFF
--- a/packages/vite-plugin-checker/src/checkers/eslint/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/eslint/main.ts
@@ -81,8 +81,9 @@ const createDiagnostic: CreateDiagnostic<'eslint'> = (pluginConfig) => {
 
       const handleFileChange = async (filePath: string, type: 'change' | 'unlink') => {
         const absPath = path.resolve(root, filePath)
+        const isChangedFileIgnored = await eslint.isPathIgnored(filePath)
 
-        if (type === 'unlink') {
+        if (type === 'unlink' || isChangedFileIgnored) {
           manager.updateByFileId(absPath, [])
         } else if (type === 'change') {
           const diagnosticsOfChangedFile = await eslint.lintFiles(filePath)

--- a/packages/vite-plugin-checker/src/checkers/eslint/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/eslint/main.ts
@@ -83,7 +83,9 @@ const createDiagnostic: CreateDiagnostic<'eslint'> = (pluginConfig) => {
         const absPath = path.resolve(root, filePath)
         const isChangedFileIgnored = await eslint.isPathIgnored(filePath)
 
-        if (type === 'unlink' || isChangedFileIgnored) {
+        if (isChangedFileIgnored) return
+
+        if (type === 'unlink') {
           manager.updateByFileId(absPath, [])
         } else if (type === 'change') {
           const diagnosticsOfChangedFile = await eslint.lintFiles(filePath)


### PR DESCRIPTION
I started configuring `vite-plugin-checker` for one of my projects today, and I ran into the same issue described in #115. I'm not entirely clear why that issue was closed, as it seemed to me that `vite-plugin-checker` was still trying to lint ignored files, even in the latest release.

This PR updates the ESLint checker to resolve #115 more directly. Now, when a file changes, the plugin calls [`eslint.isPathIgnored`](https://eslint.org/docs/latest/developer-guide/nodejs-api#-eslintispathignoredfilepath) to see if the file has been ignored in the ESLint config. This should avoid the warning.