### PR TITLE
Changed overflow style and opacity

### DIFF
--- a/packages/runtime/src/App.svelte
+++ b/packages/runtime/src/App.svelte
@@ -42,7 +42,8 @@
 
   .window {
     font-family: sans-serif;
-    background-color: rgb(11, 21, 33);
+    background-color: rgba(11, 21, 33, 0.85);
+    backdrop-filter: blur(1px);
     color: white;
     position: fixed;
     bottom: 0px;
@@ -72,7 +73,7 @@
 
   .list-scroll {
     height: 100%;
-    overflow: scroll;
+    overflow-y: auto;
     flex-grow: 1;
   }
 

--- a/packages/runtime/src/components/Diagnostic.svelte
+++ b/packages/runtime/src/components/Diagnostic.svelte
@@ -68,7 +68,7 @@
   }
 
   .message-item {
-    border-bottom: 1px dotted #666;
+    border-bottom: 2px dashed #838383;
     padding: 12px 0 0 0;
   }
 
@@ -89,7 +89,7 @@
   .frame {
     margin: 1em 0;
     padding: 6px 8px;
-    background: #16181d;
+    background: rgba(22, 24, 29, 0.85);
     margin-top: 8px;
     border-radius: 8px;
   }

--- a/packages/runtime/src/components/Diagnostic.svelte
+++ b/packages/runtime/src/components/Diagnostic.svelte
@@ -68,7 +68,7 @@
   }
 
   .message-item {
-    border-bottom: 2px dashed #838383;
+    border-bottom: 1px dotted #666;
     padding: 12px 0 0 0;
   }
 


### PR DESCRIPTION
The overflow bars catch the eye a lot so i made them show up only when needed, i also added a bit of opacity so that you can see below the overlay, the opacity could be reduced further, blur could be removed or increased too.
Previous:
![image](https://user-images.githubusercontent.com/59029985/187181530-ff090dcb-d85c-499a-a7de-5659bb5f3e0c.png)
After:
![image](https://user-images.githubusercontent.com/59029985/187181557-5b3e3b95-ff1b-4afe-9c03-7dee35b22e6d.png)
