### PR TITLE
fix: Ignore unknown extensions when running ESLint

### DIFF
--- a/playground/multiple-hmr/__tests__/test.spec.ts
+++ b/playground/multiple-hmr/__tests__/test.spec.ts
@@ -48,6 +48,27 @@ describe('multiple-hmr', () => {
       expect(stringify(stable(diagnostics))).toMatchSnapshot()
       expect(stripedLog).toMatchSnapshot()
     })
+
+    it('should ignore extensions that are not specified for ESLint', async () => {
+      const source = 'text-align: center;'
+      const target = 'text-align: right;'
+
+      console.log('-- edit the file --')
+      resetDiagnostics()
+      resetReceivedLog()
+      editFile('src/App.css', (code) => code.replace(source, target))
+      await sleepForEdit()
+      expect(diagnostics).toStrictEqual([])
+      expect(stripedLog).toBe('')
+
+      console.log('-- return to previous state --')
+      resetDiagnostics()
+      resetReceivedLog()
+      editFile('src/App.css', (code) => code.replace(target, source))
+      await sleepForEdit()
+      expect(diagnostics).toStrictEqual([])
+      expect(stripedLog).toBe('')
+    })
   })
 
   describe.runIf(isBuild)('build', () => {


### PR DESCRIPTION
Having the extensions to filter like defined like this:
```js
eslint: {
  lintCommand: 'eslint --ext .js,.ts,.vue ./',
},
```
When updating a file that has a different extension such as `package.json`, it tries to lint the file, which results in errors. This only happens on file changes.

I would have expected ESLint to handle this, but that's not the case. After some discussion they decided to leave this to `ESLint` class users to handle. See https://github.com/eslint/eslint/pull/4465.