### PR TITLE
fix(typescript): Support custom path in build mode

### DIFF
--- a/packages/vite-plugin-checker/src/checkers/typescript/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/typescript/main.ts
@@ -152,7 +152,13 @@ export class TscChecker extends Checker<'typescript'> {
             // Custom config path
             if (tsconfigPath) {
               const fullConfigPath = root ? path.join(root, tsconfigPath) : tsconfigPath
-              args = args.concat(['-p', fullConfigPath])
+
+              // In build mode, the tsconfig path is an argument to -b, e.g. "tsc -b [path]"
+              if (buildMode) {
+                args = args.concat([fullConfigPath])
+              } else {
+                args = args.concat(['-p', fullConfigPath])
+              }
             }
 
             return ['tsc', args]


### PR DESCRIPTION
**Context**
This PR is a small patch to the behavior when both `buildMode` and `tsConfigPath` options are used together.

This patch is a workaround for a larger use-case.

**Use case**
- For local dev (i.e. `vite`), enable static typechecking w/o emitting any output.
- For building (i.e. `vite build`), emit.

This is possible today with `buildMode`.

The gap is when specifically when building a [library](https://vitejs.dev/guide/build.html#library-mode). In this scenario, vite compiles the typescript but another tool is needed to emit the declaration files. This is because [vite does not generate declaration files for you](https://github.com/vitejs/vite/issues/3461).

`vite-plugin-checker` internally controls the `--noEmit` flag based on whether `buildMode` is true or false. As a result, my `tsconfig.json` cannot have:

```
{
  "compilerOptions": {
    "declaration": true,
    "emitDeclarationOnly": true
  }
}
```

...or else, you get an error from TypeScript that looks something like:

> Option 'emitDeclarationOnly' cannot be specified with option 'noEmit'.

Ideally, `vite-plugin-checker` would expose more granular control over the arguments. For example, it would be nice to be able to directly specify tsConfig that takes precedence over tsconfig.json. Something like:

```
checker({
  typescript: {
    tsConfig: command === 'build' ? {
      compilerOptions: {
        declaration: true,
        emitDeclarationOnly: true,
     }  : undefined,
  },
}),
```

This would extend the plugin-specific config on top of tsconfig.json to be able to have control over ts behavior specifically based on build vs dev. I have seen this as a common approach in other popular libraries.

I understand that this may be more challenging to pull off, and conflicts with some of the other plugin-level behaviors (e.g. what do we do if `noEmit` is provided in `tsConfig`?). It also takes more thought w.r.t. the longer term implications.

This PR does not attempt to tackle that effort or address these harder questions. Instead, it works around it by using a different tsconfig.json when in build mode. For example:

tsconfig.json:
```
{
  "extends": "./tsconfig.json",
  "compilerOptions": {
    // These two options are used to emit the *.d.ts files whenever typescript is run.
    // This will happen when "vite build" is run thanks to the vite-plugin-checker.
    // However it requires a separate config file because these options cannot be used
    // in combination with noEmit, which is controlled internally by the plugin.
    "declaration": true,
    "emitDeclarationOnly": true,
    "outDir": "./dist",
  }
}
```

vite.config.js:
```
plugins: [
  // Vite does not emit declaration files when "vite build" is run.
  // Instead, we need to run typescript directly in order to emit the declaration files.
  // Since we are already using vite-plugin-checker for typechecking, we can simply have
  // the same plugin emit the declaration files by using "build mode".
  // When running in "build mode", a separate configuration file must also be used to
  // emit declaration files. This is because the options cannot be used with "noEmit",
  // which is controlled internally by vite-plugin-checker any time buildMode is not true.
  // @see https://github.com/vitejs/vite/issues/3461
  // @see https://vite-plugin-checker.netlify.app/checkers/typescript.html
  // @see https://github.com/fi3ework/vite-plugin-checker/pull/186
  checker({
    typescript: {
      buildMode: command === 'build' ? true : false,
      tsconfigPath: command === 'build' ? 'tsconfig.build.json' : 'tsconfig.json',
    },
  }),
],
```

This PR would also address #181