### PR TITLE
fix: set plugin as force: 'pre'

### DIFF
--- a/packages/vite-plugin-checker/src/main.ts
+++ b/packages/vite-plugin-checker/src/main.ts
@@ -60,6 +60,7 @@ export function checker(userConfig: UserPluginConfig): Plugin {
 
   return {
     name: 'vite-plugin-checker',
+    enforce: 'pre',
     // @ts-ignore
     __internal__checker: Checker,
     config: async (config, env) => {


### PR DESCRIPTION
references https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/src/index.ts since the runtime injection is quite similar.