### PR TITLE
fix: use import.meta.hot.on to do client server communication

### DIFF
--- a/packages/runtime/src/ws.js
+++ b/packages/runtime/src/ws.js
@@ -1,17 +1,4 @@
 // #region
-// copied from https://github.com/vitejs/vite/blob/d76db0cae645beaecd970d95b4819158c5dd568a/packages/vite/src/client/client.ts#LL25
-// use server configuration, then fallback to inference
-const importMetaUrl = new URL(import.meta.url)
-
-const socketProtocol = __HMR_PROTOCOL__ || (location.protocol === 'https:' ? 'wss' : 'ws')
-const hmrPort = __HMR_PORT__
-const socketHost = `${__HMR_HOSTNAME__ || importMetaUrl.hostname}:${
-  hmrPort || importMetaUrl.port
-}${__HMR_BASE__}`
-const socket = new WebSocket(`${socketProtocol}://${socketHost}`, 'vite-hmr')
-// #endregion
-
-// #region
 // NOTE: sync modification with packages/vite-plugin-checker/client/index.ts
 const WS_CHECKER_ERROR_EVENT = 'vite-plugin-checker:error'
 const WS_CHECKER_RECONNECT_EVENT = 'vite-plugin-checker:reconnect'
@@ -34,28 +21,24 @@ export function listenToReconnectMessage(cb) {
 }
 
 export function prepareListen() {
-  const onMessage = async ({ data: dataStr }) => {
-    const data = JSON.parse(dataStr)
-    switch (data.type) {
-      case 'update':
+  const onMessage = async (data) => {
+    switch (data.event) {
+      case WS_CHECKER_ERROR_EVENT:
+        onCustomMessage.forEach((callbackfn) => callbackfn(data.data))
         break
-      case 'full-reload':
+      case WS_CHECKER_RECONNECT_EVENT:
+        onReconnectMessage.forEach((callbackfn) => callbackfn(data.data))
         break
-    }
-
-    if (data.type === 'custom') {
-      switch (data.event) {
-        case WS_CHECKER_ERROR_EVENT:
-          onCustomMessage.forEach((callbackfn) => callbackfn(data.data))
-          break
-        case WS_CHECKER_RECONNECT_EVENT:
-          onReconnectMessage.forEach((callbackfn) => callbackfn(data.data))
-          break
-      }
     }
   }
 
   return {
-    start: () => socket.addEventListener('message', onMessage),
+    start: () => {
+      if (import.meta.hot) {
+        import.meta.hot.on('vite-plugin-checker', (data) => {
+          onMessage(data)
+        })
+      }
+    },
   }
 }

--- a/playground/config-default/vite.config.js
+++ b/playground/config-default/vite.config.js
@@ -3,6 +3,7 @@ import checker from 'vite-plugin-checker'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/my-app/',
   // config-edit-slot
   plugins: [
     checker({

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -186,12 +186,16 @@ export async function startDefaultServe(_server?: ViteDevServer, port?: number):
     }`
 
     const rawWsSend = server.ws.send
-    server.ws.send = (_payload) => {
-      if (_payload.type === 'custom' && _payload.event === 'vite-plugin-checker:error') {
-        diagnostics = _payload.data.diagnostics
+    server.ws.send = (...args) => {
+      const type = args?.[0]
+      const payload = args?.[1]
+
+      if (type === 'vite-plugin-checker' && payload.event === 'vite-plugin-checker:error') {
+        diagnostics = payload.data.diagnostics
       }
 
-      return rawWsSend(_payload)
+      // @ts-ignore
+      return rawWsSend(...args)
     }
 
     await page.goto(viteTestUrl)

--- a/vitest.config.e2e.ts
+++ b/vitest.config.e2e.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     hookTimeout: timeout,
     globals: true,
     reporters: 'dot',
-    outputTruncateLength: 999999999,
+    outputTruncateLength: Infinity,
     onConsoleLog(log) {
       if (log.match(/experimental|jit engine|emitted file|tailwind/i)) return false
     },


### PR DESCRIPTION
Wish I could know #200 earlier. Lots of time is wasted in handling port and dev base calculation, use Vite's native method `import.meta.hot.on` will never have that pain.
Could also fix #189, if Vite can work correctly with a reverse proxy, the plugin will, too.