### PR TITLE
add eslint line lintCommand run delay

### DIFF
--- a/packages/vite-plugin-checker/src/checkers/eslint/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/eslint/main.ts
@@ -18,6 +18,7 @@ import {
 import { ACTION_TYPES, DiagnosticLevel } from '../../types.js'
 import { translateOptions } from './cli.js'
 import { options as optionator } from './options.js'
+import { sleep } from '../../utils';
 
 const __filename = fileURLToPath(import.meta.url)
 
@@ -83,6 +84,7 @@ const createDiagnostic: CreateDiagnostic<'eslint'> = (pluginConfig) => {
       }
 
       const handleFileChange = async (filePath: string, type: 'change' | 'unlink') => {
+         if (pluginConfig.eslint && pluginConfig.eslint.delay) await sleep(pluginConfig.eslint.delay);
         // See: https://github.com/eslint/eslint/pull/4465
         const extension = path.extname(filePath)
         const { extensions } = eslintOptions
@@ -121,10 +123,8 @@ const createDiagnostic: CreateDiagnostic<'eslint'> = (pluginConfig) => {
       watcher.add(files)
       watcher.on('change', async (filePath) => {
         handleFileChange(filePath, 'change')
-      })
       watcher.on('unlink', async (filePath) => {
         handleFileChange(filePath, 'unlink')
-      })
     },
   }
 }

--- a/packages/vite-plugin-checker/src/types.ts
+++ b/packages/vite-plugin-checker/src/types.ts
@@ -58,6 +58,10 @@ export type EslintConfig =
         /** which level of the diagnostic will be emitted from plugin */
         logLevel: ('error' | 'warning')[]
       }>
+      /**
+       * lintCommand will delay running, work with editor lint on save.
+       */
+      delay?: number
     }
 
 /** Stylelint checker configuration */

--- a/packages/vite-plugin-checker/src/utils.ts
+++ b/packages/vite-plugin-checker/src/utils.ts
@@ -3,3 +3,10 @@ import { isMainThread as _isMainThread, threadId } from 'worker_threads'
 // since vitest run all cases in worker thread, we should compatible with it to pass E2E tests
 export const isInVitestEntryThread = threadId === 1 && process.env['VITEST']
 export const isMainThread = _isMainThread || isInVitestEntryThread
+export const sleep = (time: number) => {
+  return new Promise<void>(resolve => {
+    setTimeout(() => {
+      resolve();
+    }, time);
+  });
+};


### PR DESCRIPTION
When the editor set lint on save, it will cause the code to be formatted but checker still report an error.