### PR TITLE
Use overrideConfig files for watcher

### DIFF
--- a/packages/vite-plugin-checker/src/checkers/stylelint/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/stylelint/main.ts
@@ -105,7 +105,8 @@ const createDiagnostic: CreateDiagnostic<'stylelint'> = (pluginConfig) => {
         cwd: root,
         ignored: (path: string) => path.includes('node_modules'),
       })
-      watcher.add(translatedOptions.files as string)
+      const watchPath = pluginConfig.stylelint.dev?.overrideConfig?.files ?? translatedOptions.files
+      watcher.add(watchPath as string)
       watcher.on('change', async (filePath) => {
         handleFileChange(filePath, 'change')
       })


### PR DESCRIPTION
Make sure to use the `overrideConfig.files` path for watching if it has been defined. This is needed for cases where you might want to quote your `lintCommand` files (e.g. `lintCommand: 'stylelint "src/**/*.{scss,css}"'`). In those cases `translatedOptions.files` becomes `"src/**/*.{scss,css}"` (i.e. including the quotes around it). This though does break the watcher, since it won't watch the actual files having the quotes around it. We already take the `overrideConfig.files` into account a couple when running the actual `stylelint.lint` call, but we should also take them into account for setting up the watcher.