### PR TITLE
fix: Eslint filePath error

### DIFF
--- a/packages/vite-plugin-checker/src/checkers/eslint/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/eslint/main.ts
@@ -95,14 +95,14 @@ const createDiagnostic: CreateDiagnostic<'eslint'> = (pluginConfig) => {
         const hasExtensionsConfig = Array.isArray(extensions)
         if (hasExtensionsConfig && !extensions.includes(extension)) return
 
-        const isChangedFileIgnored = await eslint.isPathIgnored(filePath)
+        const absPath = path.resolve(root, filePath)
+        const isChangedFileIgnored = await eslint.isPathIgnored(absPath)
         if (isChangedFileIgnored) return
 
-        const absPath = path.resolve(root, filePath)
         if (type === 'unlink') {
           manager.updateByFileId(absPath, [])
         } else if (type === 'change') {
-          const diagnosticsOfChangedFile = await eslint.lintFiles(filePath)
+          const diagnosticsOfChangedFile = await eslint.lintFiles(absPath)
           const newDiagnostics = diagnosticsOfChangedFile
             .map((d) => normalizeEslintDiagnostic(d))
             .flat(1)


### PR DESCRIPTION
Eslint Error: No files matching, when root and dev.overrideConfig.cwd are different
[example:https://stackblitz.com/edit/vitejs-vite-xjr4n6?file=vite.config.ts ](https://stackblitz.com/edit/vitejs-vite-xjr4n6?file=vite.config.ts)