### PR TITLE
feat: add optional global configuration of root directory

### DIFF
--- a/docs/configuration/config.md
+++ b/docs/configuration/config.md
@@ -57,5 +57,11 @@ Shared configuration to control the checker behaviors of the plugin.
    * @defaultValue `true`
    */
   enableBuild: boolean
+
+  /**
+   * Configure root directory of checkers
+   * @defaultValue no default value
+   */
+  root?: boolean;
 }
 ```

--- a/packages/vite-plugin-checker/src/main.ts
+++ b/packages/vite-plugin-checker/src/main.ts
@@ -175,7 +175,7 @@ export function checker(userConfig: UserPluginConfig): Plugin {
       // Get the server instance and keep reference in a closure
       checkers.forEach((checker, index) => {
         const { worker, configureServer: workerConfigureServer } = checker.serve
-        workerConfigureServer({ root: server.config.root })
+        workerConfigureServer({ root: userConfig.root || server.config.root })
         worker.on('message', (action: Action) => {
           if (action.type === ACTION_TYPES.overlayError) {
             latestOverlayErrors[index] = action.payload as ClientDiagnosticPayload

--- a/packages/vite-plugin-checker/src/types.ts
+++ b/packages/vite-plugin-checker/src/types.ts
@@ -160,6 +160,11 @@ export interface SharedConfig {
    * @defaultValue `true`
    */
   enableBuild: boolean
+  /**
+   * Configure root directory of checkers
+   * @defaultValue no default value
+   */
+  root?: string
 }
 
 export interface BuildInCheckers {


### PR DESCRIPTION
This MR adds a new optional configuration property `root`

In our project, we want some checkers to run in a different root directory. This property enables us to do so.

```js

checker({
	root: path.resolve(__dirname, "../foo"),
	typescript: true,
	eslint: {
		lintCommand: 'eslint "**/*.{js,ts,tsx}" --cache --max-warnings 0',
	},
}),
```