### PR TITLE
docs: update vue-tsc vue 2 support section

### DIFF
--- a/docs/checkers/vue-tsc.md
+++ b/docs/checkers/vue-tsc.md
@@ -11,7 +11,7 @@ You can use vue-tsc checker for your Vue3 project. If you're still using Vue2, c
    ```
 
    ::: tip
-   The `vue-tsc` version **must** >= `0.33.9`. `vue-tsc` has released `1.0.0` version, it's recommended to try it out.
+   The `vue-tsc` version **must** be >= `0.33.9`. `vue-tsc` has released a `1.0.0` version, it's recommended to try it out.
    :::
 
 2. Add `vueTsc` field to plugin config.
@@ -31,4 +31,4 @@ Advanced object configuration table of `options.vueTsc`
 | root         | `string` | [Vite config](https://vitejs.dev/config/#root) `root` | Root path to find tsconfig file  |
 | tsconfigPath | `string` | `"tsconfig.json"`                                     | Relative tsconfig path to `root` |
 
-3. **(optional for Vue2 project only)** The type check is powered by `vue-tsc` so it supports Vue2 according to the [documentation](https://github.com/johnsoncodehk/volar#using), you need to install `@vue/runtime-dom` by yourself.
+3. **(optional for Vue2 project only)** The type check is powered by `vue-tsc` so it supports Vue2. According to the [documentation](https://github.com/vuejs/language-tools/blob/master/packages/vscode-vue/README.md#usage), you need to install `@vue/runtime-dom` for Vue version <= `2.6.14`.


### PR DESCRIPTION
They moved the section this was referring to to another place. Also it is only needed for Vue 2 version `2.6.14` and lower to install `@vue/runtime-dom`.