### PR TITLE
chore: add direction ltr

### DIFF
--- a/.changeset/empty-planes-smash.md
+++ b/.changeset/empty-planes-smash.md
@@ -1,0 +1,5 @@
+---
+"@vite-plugin-checker/runtime": patch
+---
+
+fix: add explicitly ltr direction to the overlay

--- a/packages/runtime/src/App.ce.vue
+++ b/packages/runtime/src/App.ce.vue
@@ -58,6 +58,7 @@ const toggle = () => {
   --blue: #a4c1ff;
   --cyan: #2dd9da;
   --dim: #c9c9c9;
+  direction: ltr;
 }
 
 .window {


### PR DESCRIPTION
I am using this plugin in an RTL project (Persian, Arabic, and... are RTL for example and we have `<html dir='rtl'>`), and when the vite-plugin-checker shows up, its direction is not working properly and messages are hard to read. This is a tiny change to solve this issue and always LTR direction for the message area. You can see the problem here:

Issue:
![image](https://github.com/fi3ework/vite-plugin-checker/assets/16647736/9e357397-1666-451f-a2d6-5df4ba3e66ff)

After this change:
![image](https://github.com/fi3ework/vite-plugin-checker/assets/16647736/632d3b4d-ee14-4e7e-8b7f-67d8dce721b4)
