### PR TITLE
Remove lodash per method packages

### DIFF
--- a/.changeset/gentle-singers-poke.md
+++ b/.changeset/gentle-singers-poke.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-checker": patch
+---
+
+Remove lodash per method packages

--- a/packages/vite-plugin-checker/package.json
+++ b/packages/vite-plugin-checker/package.json
@@ -46,7 +46,7 @@
     "commander": "^8.0.0",
     "fast-glob": "^3.2.7",
     "fs-extra": "^11.1.0",
-    "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
     "npm-run-path": "^4.0.1",
     "semver": "^7.5.0",
     "strip-ansi": "^6.0.0",
@@ -96,7 +96,7 @@
   "devDependencies": {
     "@types/eslint": "^7.2.14",
     "@types/fs-extra": "^11.0.1",
-    "@types/lodash": "^4.14.202",
+    "@types/lodash-es": "^4.17.12",
     "@types/semver": "^7.3.13",
     "@volar/vue-typescript": "^0.33.0",
     "esbuild": "^0.14.27",

--- a/packages/vite-plugin-checker/package.json
+++ b/packages/vite-plugin-checker/package.json
@@ -46,7 +46,6 @@
     "commander": "^8.0.0",
     "fast-glob": "^3.2.7",
     "fs-extra": "^11.1.0",
-    "lodash.debounce": "^4.0.8",
     "lodash.pick": "^4.4.0",
     "npm-run-path": "^4.0.1",
     "semver": "^7.5.0",
@@ -97,7 +96,6 @@
   "devDependencies": {
     "@types/eslint": "^7.2.14",
     "@types/fs-extra": "^11.0.1",
-    "@types/lodash.debounce": "^4.0.6",
     "@types/lodash.pick": "^4.4.6",
     "@types/semver": "^7.3.13",
     "@volar/vue-typescript": "^0.33.0",

--- a/packages/vite-plugin-checker/package.json
+++ b/packages/vite-plugin-checker/package.json
@@ -46,7 +46,7 @@
     "commander": "^8.0.0",
     "fast-glob": "^3.2.7",
     "fs-extra": "^11.1.0",
-    "lodash.pick": "^4.4.0",
+    "lodash": "^4.17.21",
     "npm-run-path": "^4.0.1",
     "semver": "^7.5.0",
     "strip-ansi": "^6.0.0",
@@ -96,7 +96,7 @@
   "devDependencies": {
     "@types/eslint": "^7.2.14",
     "@types/fs-extra": "^11.0.1",
-    "@types/lodash.pick": "^4.4.6",
+    "@types/lodash": "^4.14.202",
     "@types/semver": "^7.3.13",
     "@volar/vue-typescript": "^0.33.0",
     "esbuild": "^0.14.27",

--- a/packages/vite-plugin-checker/src/main.ts
+++ b/packages/vite-plugin-checker/src/main.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 import { spawn } from 'child_process'
-import { pick } from 'lodash'
+import pick from 'lodash/pick'
 import npmRunPath from 'npm-run-path'
 
 import { Checker } from './Checker.js'

--- a/packages/vite-plugin-checker/src/main.ts
+++ b/packages/vite-plugin-checker/src/main.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 import { spawn } from 'child_process'
-import pick from 'lodash/pick.js'
+import { pick } from 'lodash-es'
 import npmRunPath from 'npm-run-path'
 
 import { Checker } from './Checker.js'

--- a/packages/vite-plugin-checker/src/main.ts
+++ b/packages/vite-plugin-checker/src/main.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 import { spawn } from 'child_process'
-import pick from 'lodash/pick'
+import pick from 'lodash/pick.js'
 import npmRunPath from 'npm-run-path'
 
 import { Checker } from './Checker.js'

--- a/packages/vite-plugin-checker/src/main.ts
+++ b/packages/vite-plugin-checker/src/main.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 import { spawn } from 'child_process'
-import pick from 'lodash.pick'
+import { pick } from 'lodash'
 import npmRunPath from 'npm-run-path'
 
 import { Checker } from './Checker.js'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,7 +127,7 @@ importers:
       '@babel/code-frame': ^7.12.13
       '@types/eslint': ^7.2.14
       '@types/fs-extra': ^11.0.1
-      '@types/lodash': ^4.14.202
+      '@types/lodash-es': ^4.17.12
       '@types/semver': ^7.3.13
       '@volar/vue-typescript': ^0.33.0
       ansi-escapes: ^4.3.0
@@ -137,7 +137,7 @@ importers:
       esbuild: ^0.14.27
       fast-glob: ^3.2.7
       fs-extra: ^11.1.0
-      lodash: ^4.17.21
+      lodash-es: ^4.17.21
       meow: ^9.0.0
       npm-run-all: ^4.1.5
       npm-run-path: ^4.0.1
@@ -163,7 +163,7 @@ importers:
       commander: 8.3.0
       fast-glob: 3.2.11
       fs-extra: 11.1.0
-      lodash: 4.17.21
+      lodash-es: 4.17.21
       npm-run-path: 4.0.1
       semver: 7.5.0
       strip-ansi: 6.0.1
@@ -175,7 +175,7 @@ importers:
     devDependencies:
       '@types/eslint': 7.29.0
       '@types/fs-extra': 11.0.1
-      '@types/lodash': 4.14.202
+      '@types/lodash-es': 4.17.12
       '@types/semver': 7.3.13
       '@volar/vue-typescript': 0.33.9
       esbuild: 0.14.54
@@ -2013,6 +2013,12 @@ packages:
     resolution: {integrity: sha512-mXlRDFbTLpVysvxahXUQav0hFctgu3Fqr2xmSrpf/ptO/FwOp7SFEGsJkEihwshMbof3/BIiVJ/o42cuOOuv6g==}
     dependencies:
       '@types/node': 16.11.49
+    dev: true
+
+  /@types/lodash-es/4.17.12:
+    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
+    dependencies:
+      '@types/lodash': 4.14.202
     dev: true
 
   /@types/lodash/4.14.202:
@@ -6006,6 +6012,10 @@ packages:
       p-locate: 5.0.0
     dev: true
 
+  /lodash-es/4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+    dev: false
+
   /lodash.clonedeep/4.5.0:
     resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
     dev: true
@@ -6036,6 +6046,7 @@ packages:
 
   /lodash/4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: true
 
   /log-update/4.0.0:
     resolution: {integrity: sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,7 +127,7 @@ importers:
       '@babel/code-frame': ^7.12.13
       '@types/eslint': ^7.2.14
       '@types/fs-extra': ^11.0.1
-      '@types/lodash.pick': ^4.4.6
+      '@types/lodash': ^4.14.202
       '@types/semver': ^7.3.13
       '@volar/vue-typescript': ^0.33.0
       ansi-escapes: ^4.3.0
@@ -137,7 +137,7 @@ importers:
       esbuild: ^0.14.27
       fast-glob: ^3.2.7
       fs-extra: ^11.1.0
-      lodash.pick: ^4.4.0
+      lodash: ^4.17.21
       meow: ^9.0.0
       npm-run-all: ^4.1.5
       npm-run-path: ^4.0.1
@@ -163,7 +163,7 @@ importers:
       commander: 8.3.0
       fast-glob: 3.2.11
       fs-extra: 11.1.0
-      lodash.pick: 4.4.0
+      lodash: 4.17.21
       npm-run-path: 4.0.1
       semver: 7.5.0
       strip-ansi: 6.0.1
@@ -175,7 +175,7 @@ importers:
     devDependencies:
       '@types/eslint': 7.29.0
       '@types/fs-extra': 11.0.1
-      '@types/lodash.pick': 4.4.7
+      '@types/lodash': 4.14.202
       '@types/semver': 7.3.13
       '@volar/vue-typescript': 0.33.9
       esbuild: 0.14.54
@@ -2015,14 +2015,8 @@ packages:
       '@types/node': 16.11.49
     dev: true
 
-  /@types/lodash.pick/4.4.7:
-    resolution: {integrity: sha512-HgdyKz7/1+oeoVzbpu1XiX/Bti9AUksHtOILH38T07aKvqoirzcdOsrO2+Yg3L51Hv/8m1MetvHZEUGeABiTiQ==}
-    dependencies:
-      '@types/lodash': 4.14.182
-    dev: true
-
-  /@types/lodash/4.14.182:
-    resolution: {integrity: sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==}
+  /@types/lodash/4.14.202:
+    resolution: {integrity: sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==}
     dev: true
 
   /@types/mime/3.0.1:
@@ -6028,10 +6022,6 @@ packages:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
 
-  /lodash.pick/4.4.0:
-    resolution: {integrity: sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==}
-    dev: false
-
   /lodash.sortby/4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
     dev: true
@@ -6046,7 +6036,6 @@ packages:
 
   /lodash/4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-    dev: true
 
   /log-update/4.0.0:
     resolution: {integrity: sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,7 +127,6 @@ importers:
       '@babel/code-frame': ^7.12.13
       '@types/eslint': ^7.2.14
       '@types/fs-extra': ^11.0.1
-      '@types/lodash.debounce': ^4.0.6
       '@types/lodash.pick': ^4.4.6
       '@types/semver': ^7.3.13
       '@volar/vue-typescript': ^0.33.0
@@ -138,7 +137,6 @@ importers:
       esbuild: ^0.14.27
       fast-glob: ^3.2.7
       fs-extra: ^11.1.0
-      lodash.debounce: ^4.0.8
       lodash.pick: ^4.4.0
       meow: ^9.0.0
       npm-run-all: ^4.1.5
@@ -165,7 +163,6 @@ importers:
       commander: 8.3.0
       fast-glob: 3.2.11
       fs-extra: 11.1.0
-      lodash.debounce: 4.0.8
       lodash.pick: 4.4.0
       npm-run-path: 4.0.1
       semver: 7.5.0
@@ -178,7 +175,6 @@ importers:
     devDependencies:
       '@types/eslint': 7.29.0
       '@types/fs-extra': 11.0.1
-      '@types/lodash.debounce': 4.0.7
       '@types/lodash.pick': 4.4.7
       '@types/semver': 7.3.13
       '@volar/vue-typescript': 0.33.9
@@ -2017,12 +2013,6 @@ packages:
     resolution: {integrity: sha512-mXlRDFbTLpVysvxahXUQav0hFctgu3Fqr2xmSrpf/ptO/FwOp7SFEGsJkEihwshMbof3/BIiVJ/o42cuOOuv6g==}
     dependencies:
       '@types/node': 16.11.49
-    dev: true
-
-  /@types/lodash.debounce/4.0.7:
-    resolution: {integrity: sha512-X1T4wMZ+gT000M2/91SYj0d/7JfeNZ9PeeOldSNoE/lunLeQXKvkmIumI29IaKMotU/ln/McOIvgzZcQ/3TrSA==}
-    dependencies:
-      '@types/lodash': 4.14.182
     dev: true
 
   /@types/lodash.pick/4.4.7:
@@ -6025,10 +6015,6 @@ packages:
   /lodash.clonedeep/4.5.0:
     resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
     dev: true
-
-  /lodash.debounce/4.0.8:
-    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
-    dev: false
 
   /lodash.iserror/3.1.1:
     resolution: {integrity: sha512-eT/VeNns9hS7vAj1NKW/rRX6b+C3UX3/IAAqEE7aC4Oo2C0iD82NaP5IS4bSlQsammTii4qBJ8G1zd1LTL8hCw==}


### PR DESCRIPTION
fixes https://github.com/fi3ework/vite-plugin-checker/issues/297

- removes package `lodash.debounce` (I could not find any use of this package)
- removes package `lodash.pick` in favor of `lodash` (see https://lodash.com/per-method-packages)
