### PR TITLE
Remove lodash

### DIFF
--- a/.changeset/curvy-starfishes-beam.md
+++ b/.changeset/curvy-starfishes-beam.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-checker": patch
+---
+
+Remove lodash-es from dependencies

--- a/packages/vite-plugin-checker/package.json
+++ b/packages/vite-plugin-checker/package.json
@@ -46,7 +46,6 @@
     "commander": "^8.0.0",
     "fast-glob": "^3.2.7",
     "fs-extra": "^11.1.0",
-    "lodash-es": "^4.17.21",
     "npm-run-path": "^4.0.1",
     "semver": "^7.5.0",
     "strip-ansi": "^6.0.0",
@@ -96,7 +95,6 @@
   "devDependencies": {
     "@types/eslint": "^7.2.14",
     "@types/fs-extra": "^11.0.1",
-    "@types/lodash-es": "^4.17.12",
     "@types/semver": "^7.3.13",
     "@volar/vue-typescript": "^0.33.0",
     "esbuild": "^0.14.27",

--- a/packages/vite-plugin-checker/src/main.ts
+++ b/packages/vite-plugin-checker/src/main.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk'
 import { spawn } from 'child_process'
-import { pick } from 'lodash-es'
 import npmRunPath from 'npm-run-path'
 
 import { Checker } from './Checker.js'
@@ -21,12 +20,10 @@ import {
   type Action,
   type PluginConfig,
   type ServeAndBuildChecker,
-  type SharedConfig,
   type UserPluginConfig,
 } from './types.js'
 import type { ConfigEnv, Plugin, Logger } from 'vite'
 
-const sharedConfigKeys: (keyof SharedConfig)[] = ['enableBuild', 'overlay']
 const buildInCheckerKeys: BuildInCheckerNames[] = [
   'typescript',
   'vueTsc',
@@ -40,7 +37,8 @@ async function createCheckers(
   env: ConfigEnv
 ): Promise<ServeAndBuildChecker[]> {
   const serveAndBuildCheckers: ServeAndBuildChecker[] = []
-  const sharedConfig = pick(userConfig, sharedConfigKeys)
+  const { enableBuild, overlay } = userConfig
+  const sharedConfig = { enableBuild, overlay }
 
   // buildInCheckerKeys.forEach(async (name: BuildInCheckerNames) => {
   for (const name of buildInCheckerKeys) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,7 +127,6 @@ importers:
       '@babel/code-frame': ^7.12.13
       '@types/eslint': ^7.2.14
       '@types/fs-extra': ^11.0.1
-      '@types/lodash-es': ^4.17.12
       '@types/semver': ^7.3.13
       '@volar/vue-typescript': ^0.33.0
       ansi-escapes: ^4.3.0
@@ -137,7 +136,6 @@ importers:
       esbuild: ^0.14.27
       fast-glob: ^3.2.7
       fs-extra: ^11.1.0
-      lodash-es: ^4.17.21
       meow: ^9.0.0
       npm-run-all: ^4.1.5
       npm-run-path: ^4.0.1
@@ -163,7 +161,6 @@ importers:
       commander: 8.3.0
       fast-glob: 3.2.11
       fs-extra: 11.1.0
-      lodash-es: 4.17.21
       npm-run-path: 4.0.1
       semver: 7.5.0
       strip-ansi: 6.0.1
@@ -175,7 +172,6 @@ importers:
     devDependencies:
       '@types/eslint': 7.29.0
       '@types/fs-extra': 11.0.1
-      '@types/lodash-es': 4.17.12
       '@types/semver': 7.3.13
       '@volar/vue-typescript': 0.33.9
       esbuild: 0.14.54
@@ -2081,16 +2077,6 @@ packages:
     resolution: {integrity: sha512-mXlRDFbTLpVysvxahXUQav0hFctgu3Fqr2xmSrpf/ptO/FwOp7SFEGsJkEihwshMbof3/BIiVJ/o42cuOOuv6g==}
     dependencies:
       '@types/node': 16.11.49
-    dev: true
-
-  /@types/lodash-es/4.17.12:
-    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
-    dependencies:
-      '@types/lodash': 4.14.202
-    dev: true
-
-  /@types/lodash/4.14.202:
-    resolution: {integrity: sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==}
     dev: true
 
   /@types/mime/3.0.1:
@@ -6266,10 +6252,6 @@ packages:
     dependencies:
       p-locate: 5.0.0
     dev: true
-
-  /lodash-es/4.17.21:
-    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
-    dev: false
 
   /lodash.clonedeep/4.5.0:
     resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}


### PR DESCRIPTION
It looks like [the move to lodash-es](https://github.com/fi3ework/vite-plugin-checker/pull/299) actually [broke things](https://github.com/fi3ework/vite-plugin-checker/issues/302) (and I kind of feel responsible for that)

It turns out this project has a dependency on lodash for a single use of `pick()`.

Let's remove lodash? What do you think?