### PR TITLE
chore: Restrict vue-tsc to Version 1 Due to Compatibility Issues with Version 2

### DIFF
--- a/docs/checkers/vue-tsc.md
+++ b/docs/checkers/vue-tsc.md
@@ -10,8 +10,8 @@ You can use vue-tsc checker for your Vue3 project. If you're still using Vue2, c
    pnpm add vue-tsc@latest typescript -D
    ```
 
-   ::: tip
-   The `vue-tsc` version **must** be >= `0.33.9`. `vue-tsc` has released a `1.0.0` version, it's recommended to try it out.
+   ::: warning
+   The `vue-tsc` version **must** be `^1.3.9`.
    :::
 
 2. Add `vueTsc` field to plugin config.

--- a/packages/vite-plugin-checker/package.json
+++ b/packages/vite-plugin-checker/package.json
@@ -64,7 +64,7 @@
     "vite": ">=2.0.0",
     "vls": "*",
     "vti": "*",
-    "vue-tsc": ">=1.3.9"
+    "vue-tsc": "^1.3.9"
   },
   "peerDependenciesMeta": {
     "eslint": {


### PR DESCRIPTION
### Description
This PR addresses an issue where the library is incompatible with `vue-tsc@^2.0.0`. To prevent new users from encountering the issue #306 it is important to specify that the library only supports `vue-tsc@^1.x.x` until the problem is resolved.


### Changes
Updated documentation to clarify the supported version of `vue-tsc`.
Added a warning message for users attempting to `vue-tsc@^2.0.0`.

### Issue Reference
More information can be found in issue [#306](https://chatgpt.com/c/c666253b-a9e4-4e41-badd-b5bd8a7178d5#306).