### PR TITLE
fix: bump @vitejs/plugin-vue to build runtime

### DIFF
--- a/.changeset/smooth-bags-grow.md
+++ b/.changeset/smooth-bags-grow.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-checker': patch
+---
+
+Bump @vitejs/plugin-vue to resolve runtime warning, see #346

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "strip-ansi": "^7.0.0",
     "tiny-invariant": "^1.1.0",
     "typescript": "^5.0.4",
-    "vite": "^4.3.0",
+    "vite": "^5.3.2",
     "vite-plugin-checker": "workspace:*",
     "vitest": "^1.6.0",
     "ws": "^8.5.0"

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -15,8 +15,8 @@
   },
   "devDependencies": {
     "@unplugin-vue-ce/sub-style": "1.0.0-beta.14",
-    "@vitejs/plugin-vue": "^2.0.1",
-    "vite": "^4.3.0",
+    "@vitejs/plugin-vue": "^5.0.5",
+    "vite": "^5.3.2",
     "vue": "^3.3.4",
     "vue-tsc": "^2.0.14"
   }

--- a/playground/backend-integration/package.json
+++ b/playground/backend-integration/package.json
@@ -20,7 +20,7 @@
     "express": "^4.18.2",
     "http-proxy-middleware": "^2.0.6",
     "typescript": "^5.0.4",
-    "vite": "^4.3.0",
+    "vite": "^5.3.2",
     "vite-plugin-checker": "workspace:*"
   }
 }

--- a/playground/config-default/package.json
+++ b/playground/config-default/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/parser": "^5.59.0",
     "eslint": "^8.57.0",
     "typescript": "^5.0.4",
-    "vite": "^4.3.0",
+    "vite": "^5.3.2",
     "vite-plugin-checker": "workspace:*"
   }
 }

--- a/playground/config-enableBuild-false/package.json
+++ b/playground/config-enableBuild-false/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/parser": "^5.59.0",
     "eslint": "^8.57.0",
     "typescript": "^5.0.4",
-    "vite": "^4.3.0",
+    "vite": "^5.3.2",
     "vite-plugin-checker": "workspace:*"
   }
 }

--- a/playground/config-initialIsOpen-error-warnings/package.json
+++ b/playground/config-initialIsOpen-error-warnings/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/parser": "^5.59.0",
     "eslint": "^8.57.0",
     "typescript": "^5.0.4",
-    "vite": "^4.3.0",
+    "vite": "^5.3.2",
     "vite-plugin-checker": "workspace:*"
   }
 }

--- a/playground/config-initialIsOpen-error/package.json
+++ b/playground/config-initialIsOpen-error/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/parser": "^5.59.0",
     "eslint": "^8.57.0",
     "typescript": "^5.0.4",
-    "vite": "^4.3.0",
+    "vite": "^5.3.2",
     "vite-plugin-checker": "workspace:*"
   }
 }

--- a/playground/config-initialIsOpen-false/package.json
+++ b/playground/config-initialIsOpen-false/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/parser": "^5.59.0",
     "eslint": "^8.57.0",
     "typescript": "^5.0.4",
-    "vite": "^4.3.0",
+    "vite": "^5.3.2",
     "vite-plugin-checker": "workspace:*"
   }
 }

--- a/playground/config-no-runtime-in-build/package.json
+++ b/playground/config-no-runtime-in-build/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/parser": "^5.59.0",
     "eslint": "^8.57.0",
     "typescript": "^5.0.4",
-    "vite": "^4.3.0",
+    "vite": "^5.3.2",
     "vite-plugin-checker": "workspace:*"
   }
 }

--- a/playground/config-overlay-changes/package.json
+++ b/playground/config-overlay-changes/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/parser": "^5.59.0",
     "eslint": "^8.57.0",
     "typescript": "^5.0.4",
-    "vite": "^4.3.0",
+    "vite": "^5.3.2",
     "vite-plugin-checker": "workspace:*"
   }
 }

--- a/playground/config-overlay-false/package.json
+++ b/playground/config-overlay-false/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/parser": "^5.59.0",
     "eslint": "^8.57.0",
     "typescript": "^5.0.4",
-    "vite": "^4.3.0",
+    "vite": "^5.3.2",
     "vite-plugin-checker": "workspace:*"
   }
 }

--- a/playground/config-overlay-position-style/package.json
+++ b/playground/config-overlay-position-style/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/parser": "^5.59.0",
     "eslint": "^8.57.0",
     "typescript": "^5.0.4",
-    "vite": "^4.3.0",
+    "vite": "^5.3.2",
     "vite-plugin-checker": "workspace:*"
   }
 }

--- a/playground/config-terminal-false/package.json
+++ b/playground/config-terminal-false/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/parser": "^5.59.0",
     "eslint": "^8.57.0",
     "typescript": "^5.0.4",
-    "vite": "^4.3.0",
+    "vite": "^5.3.2",
     "vite-plugin-checker": "workspace:*"
   }
 }

--- a/playground/eslint-config-log-level/package.json
+++ b/playground/eslint-config-log-level/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/eslint-plugin": "^5.59.0",
     "@typescript-eslint/parser": "^5.59.0",
     "typescript": "^5.0.4",
-    "vite": "^4.3.0",
+    "vite": "^5.3.2",
     "vite-plugin-checker": "workspace:*"
   }
 }

--- a/playground/eslint-default/package.json
+++ b/playground/eslint-default/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/eslint-plugin": "^5.59.0",
     "@typescript-eslint/parser": "^5.59.0",
     "typescript": "^5.0.4",
-    "vite": "^4.3.0",
+    "vite": "^5.3.2",
     "vite-plugin-checker": "workspace:*"
   }
 }

--- a/playground/eslint-flat/package.json
+++ b/playground/eslint-flat/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "eslint": "^8.57.0",
-    "vite": "^4.3.0",
+    "vite": "^5.3.2",
     "vite-plugin-checker": "workspace:*"
   }
 }

--- a/playground/multiple-hmr/package.json
+++ b/playground/multiple-hmr/package.json
@@ -17,7 +17,7 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^2.0.0",
     "typescript": "^5.0.4",
-    "vite": "^4.3.0",
+    "vite": "^5.3.2",
     "vite-plugin-checker": "workspace:*"
   }
 }

--- a/playground/multiple-reload/package.json
+++ b/playground/multiple-reload/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/parser": "^5.59.0",
     "eslint": "^8.57.0",
     "typescript": "^5.0.4",
-    "vite": "^4.3.0",
+    "vite": "^5.3.2",
     "vite-plugin-checker": "workspace:*"
   }
 }

--- a/playground/stylelint-default/package.json
+++ b/playground/stylelint-default/package.json
@@ -20,7 +20,7 @@
     "stylelint": "^14.0.0",
     "stylelint-config-standard": "^28.0.0",
     "typescript": "^5.0.4",
-    "vite": "^4.3.0",
+    "vite": "^5.3.2",
     "vite-plugin-checker": "workspace:*"
   }
 }

--- a/playground/typescript-react/package.json
+++ b/playground/typescript-react/package.json
@@ -17,7 +17,7 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^2.0.0",
     "typescript": "^5.0.4",
-    "vite": "^4.3.0",
+    "vite": "^5.3.2",
     "vite-plugin-checker": "workspace:*"
   }
 }

--- a/playground/vls-vue2/package.json
+++ b/playground/vls-vue2/package.json
@@ -27,7 +27,7 @@
     "prettier": "2.6.0",
     "sass": "^1.32.7",
     "typescript": "~4.3.2",
-    "vite": "^4.3.0",
+    "vite": "^5.3.2",
     "vite-plugin-checker": "workspace:*",
     "vite-plugin-components": "^0.12.2",
     "vite-plugin-vue2": "^1.9.0",

--- a/playground/vue-tsc-vue3/package.json
+++ b/playground/vue-tsc-vue3/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "^2.0.1",
     "typescript": "^5.0.4",
-    "vite": "^4.3.0",
+    "vite": "^5.3.2",
     "vite-plugin-checker": "workspace:*",
     "vue-tsc": "^2.0.14"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,8 +113,8 @@ importers:
         specifier: ^5.0.4
         version: 5.5.2
       vite:
-        specifier: ^4.3.0
-        version: 4.5.3(@types/node@16.18.101)(sass@1.77.6)
+        specifier: ^5.3.2
+        version: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vite-plugin-checker:
         specifier: workspace:*
         version: link:packages/vite-plugin-checker
@@ -146,11 +146,11 @@ importers:
         specifier: 1.0.0-beta.14
         version: 1.0.0-beta.14(ansi-colors@4.1.3)(vue@3.4.29(typescript@5.5.2))
       '@vitejs/plugin-vue':
-        specifier: ^2.0.1
-        version: 2.3.4(vite@4.5.3(@types/node@16.18.101)(sass@1.77.6))(vue@3.4.29(typescript@5.5.2))
+        specifier: ^5.0.5
+        version: 5.0.5(vite@5.3.2(@types/node@16.18.101)(sass@1.77.6))(vue@3.4.29(typescript@5.5.2))
       vite:
-        specifier: ^4.3.0
-        version: 4.5.3(@types/node@16.18.101)(sass@1.77.6)
+        specifier: ^5.3.2
+        version: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vue:
         specifier: ^3.3.4
         version: 3.4.29(typescript@5.5.2)
@@ -260,7 +260,7 @@ importers:
         version: 18.3.0
       '@vitejs/plugin-react':
         specifier: ^2.0.0
-        version: 2.2.0(vite@4.5.3(@types/node@16.18.101)(sass@1.77.6))
+        version: 2.2.0(vite@5.3.2(@types/node@16.18.101)(sass@1.77.6))
       express:
         specifier: ^4.18.2
         version: 4.19.2
@@ -271,8 +271,8 @@ importers:
         specifier: ^5.0.4
         version: 5.5.2
       vite:
-        specifier: ^4.3.0
-        version: 4.5.3(@types/node@16.18.101)(sass@1.77.6)
+        specifier: ^5.3.2
+        version: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vite-plugin-checker:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-checker
@@ -305,8 +305,8 @@ importers:
         specifier: ^5.0.4
         version: 5.5.2
       vite:
-        specifier: ^4.3.0
-        version: 4.5.3(@types/node@16.18.101)(sass@1.77.6)
+        specifier: ^5.3.2
+        version: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vite-plugin-checker:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-checker
@@ -339,8 +339,8 @@ importers:
         specifier: ^5.0.4
         version: 5.5.2
       vite:
-        specifier: ^4.3.0
-        version: 4.5.3(@types/node@16.18.101)(sass@1.77.6)
+        specifier: ^5.3.2
+        version: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vite-plugin-checker:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-checker
@@ -373,8 +373,8 @@ importers:
         specifier: ^5.0.4
         version: 5.5.2
       vite:
-        specifier: ^4.3.0
-        version: 4.5.3(@types/node@16.18.101)(sass@1.77.6)
+        specifier: ^5.3.2
+        version: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vite-plugin-checker:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-checker
@@ -407,8 +407,8 @@ importers:
         specifier: ^5.0.4
         version: 5.5.2
       vite:
-        specifier: ^4.3.0
-        version: 4.5.3(@types/node@16.18.101)(sass@1.77.6)
+        specifier: ^5.3.2
+        version: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vite-plugin-checker:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-checker
@@ -441,8 +441,8 @@ importers:
         specifier: ^5.0.4
         version: 5.5.2
       vite:
-        specifier: ^4.3.0
-        version: 4.5.3(@types/node@16.18.101)(sass@1.77.6)
+        specifier: ^5.3.2
+        version: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vite-plugin-checker:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-checker
@@ -475,8 +475,8 @@ importers:
         specifier: ^5.0.4
         version: 5.5.2
       vite:
-        specifier: ^4.3.0
-        version: 4.5.3(@types/node@16.18.101)(sass@1.77.6)
+        specifier: ^5.3.2
+        version: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vite-plugin-checker:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-checker
@@ -509,8 +509,8 @@ importers:
         specifier: ^5.0.4
         version: 5.5.2
       vite:
-        specifier: ^4.3.0
-        version: 4.5.3(@types/node@16.18.101)(sass@1.77.6)
+        specifier: ^5.3.2
+        version: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vite-plugin-checker:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-checker
@@ -543,8 +543,8 @@ importers:
         specifier: ^5.0.4
         version: 5.5.2
       vite:
-        specifier: ^4.3.0
-        version: 4.5.3(@types/node@16.18.101)(sass@1.77.6)
+        specifier: ^5.3.2
+        version: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vite-plugin-checker:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-checker
@@ -577,8 +577,8 @@ importers:
         specifier: ^5.0.4
         version: 5.5.2
       vite:
-        specifier: ^4.3.0
-        version: 4.5.3(@types/node@16.18.101)(sass@1.77.6)
+        specifier: ^5.3.2
+        version: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vite-plugin-checker:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-checker
@@ -611,8 +611,8 @@ importers:
         specifier: ^5.0.4
         version: 5.5.2
       vite:
-        specifier: ^4.3.0
-        version: 4.5.3(@types/node@16.18.101)(sass@1.77.6)
+        specifier: ^5.3.2
+        version: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vite-plugin-checker:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-checker
@@ -645,8 +645,8 @@ importers:
         specifier: ^5.0.4
         version: 5.5.2
       vite:
-        specifier: ^4.3.0
-        version: 4.5.3(@types/node@16.18.101)(sass@1.77.6)
+        specifier: ^5.3.2
+        version: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vite-plugin-checker:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-checker
@@ -679,8 +679,8 @@ importers:
         specifier: ^5.0.4
         version: 5.5.2
       vite:
-        specifier: ^4.3.0
-        version: 4.5.3(@types/node@16.18.101)(sass@1.77.6)
+        specifier: ^5.3.2
+        version: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vite-plugin-checker:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-checker
@@ -691,8 +691,8 @@ importers:
         specifier: ^8.57.0
         version: 8.57.0
       vite:
-        specifier: ^4.3.0
-        version: 4.5.3(@types/node@16.18.101)(sass@1.77.6)
+        specifier: ^5.3.2
+        version: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vite-plugin-checker:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-checker
@@ -714,13 +714,13 @@ importers:
         version: 18.3.0
       '@vitejs/plugin-react':
         specifier: ^2.0.0
-        version: 2.2.0(vite@4.5.3(@types/node@16.18.101)(sass@1.77.6))
+        version: 2.2.0(vite@5.3.2(@types/node@16.18.101)(sass@1.77.6))
       typescript:
         specifier: ^5.0.4
         version: 5.5.2
       vite:
-        specifier: ^4.3.0
-        version: 4.5.3(@types/node@16.18.101)(sass@1.77.6)
+        specifier: ^5.3.2
+        version: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vite-plugin-checker:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-checker
@@ -753,8 +753,8 @@ importers:
         specifier: ^5.0.4
         version: 5.5.2
       vite:
-        specifier: ^4.3.0
-        version: 4.5.3(@types/node@16.18.101)(sass@1.77.6)
+        specifier: ^5.3.2
+        version: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vite-plugin-checker:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-checker
@@ -787,8 +787,8 @@ importers:
         specifier: ^5.0.4
         version: 5.5.2
       vite:
-        specifier: ^4.3.0
-        version: 4.5.3(@types/node@16.18.101)(sass@1.77.6)
+        specifier: ^5.3.2
+        version: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vite-plugin-checker:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-checker
@@ -810,13 +810,13 @@ importers:
         version: 18.3.0
       '@vitejs/plugin-react':
         specifier: ^2.0.0
-        version: 2.2.0(vite@4.5.3(@types/node@16.18.101)(sass@1.77.6))
+        version: 2.2.0(vite@5.3.2(@types/node@16.18.101)(sass@1.77.6))
       typescript:
         specifier: ^5.0.4
         version: 5.5.2
       vite:
-        specifier: ^4.3.0
-        version: 4.5.3(@types/node@16.18.101)(sass@1.77.6)
+        specifier: ^5.3.2
+        version: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vite-plugin-checker:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-checker
@@ -873,17 +873,17 @@ importers:
         specifier: ~4.3.2
         version: 4.3.5
       vite:
-        specifier: ^4.3.0
-        version: 4.5.3(@types/node@15.14.9)(sass@1.77.6)
+        specifier: ^5.3.2
+        version: 5.3.2(@types/node@15.14.9)(sass@1.77.6)
       vite-plugin-checker:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-checker
       vite-plugin-components:
         specifier: ^0.12.2
-        version: 0.12.2(vite@4.5.3(@types/node@15.14.9)(sass@1.77.6))
+        version: 0.12.2(vite@5.3.2(@types/node@15.14.9)(sass@1.77.6))
       vite-plugin-vue2:
         specifier: ^1.9.0
-        version: 1.9.3(lodash@4.17.21)(vite@4.5.3(@types/node@15.14.9)(sass@1.77.6))(vue-template-compiler@2.7.16)(vue@2.7.16)
+        version: 1.9.3(lodash@4.17.21)(vite@5.3.2(@types/node@15.14.9)(sass@1.77.6))(vue-template-compiler@2.7.16)(vue@2.7.16)
       vls:
         specifier: ^0.8.5
         version: 0.8.5
@@ -902,13 +902,13 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^2.0.1
-        version: 2.3.4(vite@4.5.3(@types/node@16.18.101)(sass@1.77.6))(vue@3.4.29(typescript@5.5.2))
+        version: 2.3.4(vite@5.3.2(@types/node@16.18.101)(sass@1.77.6))(vue@3.4.29(typescript@5.5.2))
       typescript:
         specifier: ^5.0.4
         version: 5.5.2
       vite:
-        specifier: ^4.3.0
-        version: 4.5.3(@types/node@16.18.101)(sass@1.77.6)
+        specifier: ^5.3.2
+        version: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vite-plugin-checker:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-checker
@@ -1346,12 +1346,6 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.18.20':
-    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
@@ -1360,12 +1354,6 @@ packages:
 
   '@esbuild/android-arm@0.17.19':
     resolution: {integrity: sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-arm@0.18.20':
-    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -1382,12 +1370,6 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.18.20':
-    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
@@ -1396,12 +1378,6 @@ packages:
 
   '@esbuild/darwin-arm64@0.17.19':
     resolution: {integrity: sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-arm64@0.18.20':
-    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -1418,12 +1394,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.18.20':
-    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
@@ -1432,12 +1402,6 @@ packages:
 
   '@esbuild/freebsd-arm64@0.17.19':
     resolution: {integrity: sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-arm64@0.18.20':
-    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -1454,12 +1418,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.18.20':
-    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
@@ -1468,12 +1426,6 @@ packages:
 
   '@esbuild/linux-arm64@0.17.19':
     resolution: {integrity: sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm64@0.18.20':
-    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -1490,12 +1442,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.18.20':
-    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
@@ -1504,12 +1450,6 @@ packages:
 
   '@esbuild/linux-ia32@0.17.19':
     resolution: {integrity: sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.18.20':
-    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -1532,12 +1472,6 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.18.20':
-    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
@@ -1546,12 +1480,6 @@ packages:
 
   '@esbuild/linux-mips64el@0.17.19':
     resolution: {integrity: sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.18.20':
-    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -1568,12 +1496,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.18.20':
-    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
@@ -1582,12 +1504,6 @@ packages:
 
   '@esbuild/linux-riscv64@0.17.19':
     resolution: {integrity: sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.18.20':
-    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -1604,12 +1520,6 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.18.20':
-    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
@@ -1618,12 +1528,6 @@ packages:
 
   '@esbuild/linux-x64@0.17.19':
     resolution: {integrity: sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.18.20':
-    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -1640,12 +1544,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.18.20':
-    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
@@ -1654,12 +1552,6 @@ packages:
 
   '@esbuild/openbsd-x64@0.17.19':
     resolution: {integrity: sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.18.20':
-    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -1676,12 +1568,6 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.18.20':
-    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
@@ -1690,12 +1576,6 @@ packages:
 
   '@esbuild/win32-arm64@0.17.19':
     resolution: {integrity: sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-arm64@0.18.20':
-    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -1712,12 +1592,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.18.20':
-    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
@@ -1726,12 +1600,6 @@ packages:
 
   '@esbuild/win32-x64@0.17.19':
     resolution: {integrity: sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.18.20':
-    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -3388,11 +3256,6 @@ packages:
 
   esbuild@0.17.19:
     resolution: {integrity: sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==}
-    engines: {node: '>=12'}
-    hasBin: true
-
-  esbuild@0.18.20:
-    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
     engines: {node: '>=12'}
     hasBin: true
 
@@ -5397,12 +5260,12 @@ packages:
       vite: ^2.0.0-beta.23
       vue-template-compiler: ^2.2.0
 
-  vite@4.5.3:
-    resolution: {integrity: sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
+  vite@5.3.1:
+    resolution: {integrity: sha512-XBmSKRLXLxiaPYamLv3/hnP/KXDai1NDexN0FpkTaZXTfycHvkRHoenpgl/fvuK/kPbB6xAgoyiryAhQNxYmAQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': '>= 14'
+      '@types/node': ^18.0.0 || >=20.0.0
       less: '*'
       lightningcss: ^1.21.0
       sass: '*'
@@ -5425,8 +5288,8 @@ packages:
       terser:
         optional: true
 
-  vite@5.3.1:
-    resolution: {integrity: sha512-XBmSKRLXLxiaPYamLv3/hnP/KXDai1NDexN0FpkTaZXTfycHvkRHoenpgl/fvuK/kPbB6xAgoyiryAhQNxYmAQ==}
+  vite@5.3.2:
+    resolution: {integrity: sha512-6lA7OBHBlXUxiJxbO5aAY2fsHHzDr1q7DvXYnyZycRs2Dz+dXBWuhpWHvmljTRTpQC2uvGmUFFkSHF2vGo90MA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -6343,16 +6206,10 @@ snapshots:
   '@esbuild/android-arm64@0.17.19':
     optional: true
 
-  '@esbuild/android-arm64@0.18.20':
-    optional: true
-
   '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm@0.17.19':
-    optional: true
-
-  '@esbuild/android-arm@0.18.20':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
@@ -6361,16 +6218,10 @@ snapshots:
   '@esbuild/android-x64@0.17.19':
     optional: true
 
-  '@esbuild/android-x64@0.18.20':
-    optional: true
-
   '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-arm64@0.17.19':
-    optional: true
-
-  '@esbuild/darwin-arm64@0.18.20':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
@@ -6379,16 +6230,10 @@ snapshots:
   '@esbuild/darwin-x64@0.17.19':
     optional: true
 
-  '@esbuild/darwin-x64@0.18.20':
-    optional: true
-
   '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-arm64@0.17.19':
-    optional: true
-
-  '@esbuild/freebsd-arm64@0.18.20':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
@@ -6397,16 +6242,10 @@ snapshots:
   '@esbuild/freebsd-x64@0.17.19':
     optional: true
 
-  '@esbuild/freebsd-x64@0.18.20':
-    optional: true
-
   '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-arm64@0.17.19':
-    optional: true
-
-  '@esbuild/linux-arm64@0.18.20':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
@@ -6415,16 +6254,10 @@ snapshots:
   '@esbuild/linux-arm@0.17.19':
     optional: true
 
-  '@esbuild/linux-arm@0.18.20':
-    optional: true
-
   '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-ia32@0.17.19':
-    optional: true
-
-  '@esbuild/linux-ia32@0.18.20':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
@@ -6436,16 +6269,10 @@ snapshots:
   '@esbuild/linux-loong64@0.17.19':
     optional: true
 
-  '@esbuild/linux-loong64@0.18.20':
-    optional: true
-
   '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-mips64el@0.17.19':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.18.20':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
@@ -6454,16 +6281,10 @@ snapshots:
   '@esbuild/linux-ppc64@0.17.19':
     optional: true
 
-  '@esbuild/linux-ppc64@0.18.20':
-    optional: true
-
   '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-riscv64@0.17.19':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.18.20':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
@@ -6472,16 +6293,10 @@ snapshots:
   '@esbuild/linux-s390x@0.17.19':
     optional: true
 
-  '@esbuild/linux-s390x@0.18.20':
-    optional: true
-
   '@esbuild/linux-s390x@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.17.19':
-    optional: true
-
-  '@esbuild/linux-x64@0.18.20':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
@@ -6490,16 +6305,10 @@ snapshots:
   '@esbuild/netbsd-x64@0.17.19':
     optional: true
 
-  '@esbuild/netbsd-x64@0.18.20':
-    optional: true
-
   '@esbuild/netbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.17.19':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.18.20':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
@@ -6508,16 +6317,10 @@ snapshots:
   '@esbuild/sunos-x64@0.17.19':
     optional: true
 
-  '@esbuild/sunos-x64@0.18.20':
-    optional: true
-
   '@esbuild/sunos-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.17.19':
-    optional: true
-
-  '@esbuild/win32-arm64@0.18.20':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
@@ -6526,16 +6329,10 @@ snapshots:
   '@esbuild/win32-ia32@0.17.19':
     optional: true
 
-  '@esbuild/win32-ia32@0.18.20':
-    optional: true
-
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.17.19':
-    optional: true
-
-  '@esbuild/win32-x64@0.18.20':
     optional: true
 
   '@esbuild/win32-x64@0.21.5':
@@ -7044,7 +6841,7 @@ snapshots:
     transitivePeerDependencies:
       - ansi-colors
 
-  '@vitejs/plugin-react@2.2.0(vite@4.5.3(@types/node@16.18.101)(sass@1.77.6))':
+  '@vitejs/plugin-react@2.2.0(vite@5.3.2(@types/node@16.18.101)(sass@1.77.6))':
     dependencies:
       '@babel/core': 7.24.7
       '@babel/plugin-transform-react-jsx': 7.24.7(@babel/core@7.24.7)
@@ -7053,18 +6850,23 @@ snapshots:
       '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.24.7)
       magic-string: 0.26.7
       react-refresh: 0.14.2
-      vite: 4.5.3(@types/node@16.18.101)(sass@1.77.6)
+      vite: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@2.3.4(vite@4.5.3(@types/node@16.18.101)(sass@1.77.6))(vue@3.4.29(typescript@5.5.2))':
+  '@vitejs/plugin-vue@2.3.4(vite@5.3.2(@types/node@16.18.101)(sass@1.77.6))(vue@3.4.29(typescript@5.5.2))':
     dependencies:
-      vite: 4.5.3(@types/node@16.18.101)(sass@1.77.6)
+      vite: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vue: 3.4.29(typescript@5.5.2)
 
   '@vitejs/plugin-vue@5.0.5(vite@5.3.1(@types/node@16.18.101)(sass@1.77.6))(vue@3.4.29(typescript@5.5.2))':
     dependencies:
       vite: 5.3.1(@types/node@16.18.101)(sass@1.77.6)
+      vue: 3.4.29(typescript@5.5.2)
+
+  '@vitejs/plugin-vue@5.0.5(vite@5.3.2(@types/node@16.18.101)(sass@1.77.6))(vue@3.4.29(typescript@5.5.2))':
+    dependencies:
+      vite: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vue: 3.4.29(typescript@5.5.2)
 
   '@vitest/expect@1.6.0':
@@ -8105,31 +7907,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.17.19
       '@esbuild/win32-ia32': 0.17.19
       '@esbuild/win32-x64': 0.17.19
-
-  esbuild@0.18.20:
-    optionalDependencies:
-      '@esbuild/android-arm': 0.18.20
-      '@esbuild/android-arm64': 0.18.20
-      '@esbuild/android-x64': 0.18.20
-      '@esbuild/darwin-arm64': 0.18.20
-      '@esbuild/darwin-x64': 0.18.20
-      '@esbuild/freebsd-arm64': 0.18.20
-      '@esbuild/freebsd-x64': 0.18.20
-      '@esbuild/linux-arm': 0.18.20
-      '@esbuild/linux-arm64': 0.18.20
-      '@esbuild/linux-ia32': 0.18.20
-      '@esbuild/linux-loong64': 0.18.20
-      '@esbuild/linux-mips64el': 0.18.20
-      '@esbuild/linux-ppc64': 0.18.20
-      '@esbuild/linux-riscv64': 0.18.20
-      '@esbuild/linux-s390x': 0.18.20
-      '@esbuild/linux-x64': 0.18.20
-      '@esbuild/netbsd-x64': 0.18.20
-      '@esbuild/openbsd-x64': 0.18.20
-      '@esbuild/sunos-x64': 0.18.20
-      '@esbuild/win32-arm64': 0.18.20
-      '@esbuild/win32-ia32': 0.18.20
-      '@esbuild/win32-x64': 0.18.20
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -10245,7 +10022,7 @@ snapshots:
       debug: 4.3.5(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.0.1
-      vite: 5.3.1(@types/node@16.18.101)(sass@1.77.6)
+      vite: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -10256,17 +10033,17 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-components@0.12.2(vite@4.5.3(@types/node@15.14.9)(sass@1.77.6)):
+  vite-plugin-components@0.12.2(vite@5.3.2(@types/node@15.14.9)(sass@1.77.6)):
     dependencies:
       debug: 4.3.5(supports-color@8.1.1)
       fast-glob: 3.3.2
       magic-string: 0.25.9
       minimatch: 3.1.2
-      vite: 4.5.3(@types/node@15.14.9)(sass@1.77.6)
+      vite: 5.3.2(@types/node@15.14.9)(sass@1.77.6)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue2@1.9.3(lodash@4.17.21)(vite@4.5.3(@types/node@15.14.9)(sass@1.77.6))(vue-template-compiler@2.7.16)(vue@2.7.16):
+  vite-plugin-vue2@1.9.3(lodash@4.17.21)(vite@5.3.2(@types/node@15.14.9)(sass@1.77.6))(vue-template-compiler@2.7.16)(vue@2.7.16):
     dependencies:
       '@babel/core': 7.24.7
       '@babel/parser': 7.24.7
@@ -10287,7 +10064,7 @@ snapshots:
       rollup: 2.79.1
       slash: 3.0.0
       source-map: 0.7.4
-      vite: 4.5.3(@types/node@15.14.9)(sass@1.77.6)
+      vite: 5.3.2(@types/node@15.14.9)(sass@1.77.6)
       vue-template-compiler: 2.7.16
       vue-template-es2015-compiler: 1.9.1
     transitivePeerDependencies:
@@ -10347,27 +10124,27 @@ snapshots:
       - walrus
       - whiskers
 
-  vite@4.5.3(@types/node@15.14.9)(sass@1.77.6):
+  vite@5.3.1(@types/node@16.18.101)(sass@1.77.6):
     dependencies:
-      esbuild: 0.18.20
+      esbuild: 0.21.5
       postcss: 8.4.38
-      rollup: 3.29.4
-    optionalDependencies:
-      '@types/node': 15.14.9
-      fsevents: 2.3.3
-      sass: 1.77.6
-
-  vite@4.5.3(@types/node@16.18.101)(sass@1.77.6):
-    dependencies:
-      esbuild: 0.18.20
-      postcss: 8.4.38
-      rollup: 3.29.4
+      rollup: 4.18.0
     optionalDependencies:
       '@types/node': 16.18.101
       fsevents: 2.3.3
       sass: 1.77.6
 
-  vite@5.3.1(@types/node@16.18.101)(sass@1.77.6):
+  vite@5.3.2(@types/node@15.14.9)(sass@1.77.6):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.4.38
+      rollup: 4.18.0
+    optionalDependencies:
+      '@types/node': 15.14.9
+      fsevents: 2.3.3
+      sass: 1.77.6
+
+  vite@5.3.2(@types/node@16.18.101)(sass@1.77.6):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.38
@@ -10443,7 +10220,7 @@ snapshots:
       strip-literal: 2.1.0
       tinybench: 2.8.0
       tinypool: 0.8.4
-      vite: 5.3.1(@types/node@16.18.101)(sass@1.77.6)
+      vite: 5.3.2(@types/node@16.18.101)(sass@1.77.6)
       vite-node: 1.6.0(@types/node@16.18.101)(sass@1.77.6)
       why-is-node-running: 2.2.2
     optionalDependencies:


### PR DESCRIPTION
fix #346 
As per https://vuejs.org/api/compile-time-flags.html#vite, newer version of @vitejs/plugin-vue has set a default value so there will no longer this warning.