### PR TITLE
fix(vue-tsc): sync up runTsc

### DIFF
--- a/.changeset/unlucky-keys-kneel.md
+++ b/.changeset/unlucky-keys-kneel.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-checker': patch
+---
+
+sync runTsc https://github.com/volarjs/volar.js/blob/630f31118d3986c00cc730eb83cd896709fd547e/packages/typescript/lib/quickstart/runTsc.ts


### PR DESCRIPTION
resolve https://github.com/fi3ework/vite-plugin-checker/issues/351

sync up with https://github.com/volarjs/volar.js/blob/630f31118d3986c00cc730eb83cd896709fd547e/packages/typescript/lib/quickstart/runTsc.ts