### PR TITLE
fix(ui): use a Vue key so file paths update correctly

### DIFF
--- a/packages/runtime/src/components/Checker.ce.vue
+++ b/packages/runtime/src/components/Checker.ce.vue
@@ -5,11 +5,19 @@ defineProps<{
   diagnostics?: any[]
   base: string
 }>()
+
+const key = (diagnostic: any): string => {
+  if (diagnostic.loc) {
+    return `${diagnostic.loc.file}-${diagnostic.loc.line}-${diagnostic.loc.column}`;
+  } else {
+    return diagnostic.id;
+  }
+}
 </script>
 
 <template>
   <ul>
-    <Diagnostic v-for="d in diagnostics" :diagnostic="d" :base="base" />
+    <Diagnostic v-for="d in diagnostics" :diagnostic="d" :base="base" :key="key(d)" />
   </ul>
 </template>
 


### PR DESCRIPTION
this fixes a bug with this plugin where the file paths & line numbers don't update correctly after a hot reload. the error message for each entry does update while the file paths confusingly don't, therefore creating an incorrect list of errors.