### PR TITLE
fix: Point vue-tsc to patch version

### DIFF
--- a/packages/vite-plugin-checker/package.json
+++ b/packages/vite-plugin-checker/package.json
@@ -64,7 +64,7 @@
     "typescript": "^5.5.3",
     "vls": "^0.8.5",
     "vti": "^0.1.11",
-    "vue-tsc": "^2.0.14"
+    "vue-tsc": "~2.0.28"
   },
   "peerDependencies": {
     "@biomejs/biome": ">=1.7",
@@ -76,7 +76,7 @@
     "vite": ">=2.0.0",
     "vls": "*",
     "vti": "*",
-    "vue-tsc": ">=2.0.0"
+    "vue-tsc": "~2.0.28"
   },
   "peerDependenciesMeta": {
     "@biomejs/biome": {


### PR DESCRIPTION
To prevent future compatibility issues, vite-plugin-checker should point to patch versions of `vue-tsc` as you're directly using core APIs that can change between minor and major versions.

Closes https://github.com/vuejs/language-tools/issues/4755