### PR TITLE
chore(deps): upgrade `chokidar` to v4

### DIFF
--- a/packages/vite-plugin-checker/package.json
+++ b/packages/vite-plugin-checker/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@babel/code-frame": "^7.26.2",
-    "chokidar": "^3.6.0",
+    "chokidar": "^4.0.3",
     "colorette": "^2.0.20",
     "npm-run-path": "^4.0.1",
     "strip-ansi": "^6.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: ^7.26.2
         version: 7.26.2
       chokidar:
-        specifier: ^3.6.0
-        version: 3.6.0
+        specifier: ^4.0.3
+        version: 4.0.3
       colorette:
         specifier: ^2.0.20
         version: 2.0.20


### PR DESCRIPTION
https://github.com/paulmillr/chokidar/releases/tag/4.0.0

The only breaking changes are that it removes support for globs (not used here), and ups minimum required node version to 14.x (same as already used here).