### PR TITLE
test: use `globSync`

### DIFF
--- a/playground/config-no-runtime-in-build/__tests__/test.spec.ts
+++ b/playground/config-no-runtime-in-build/__tests__/test.spec.ts
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import { glob } from 'tinyglobby'
+import { globSync } from 'tinyglobby'
 import path from 'path'
 import { describe, expect, it } from 'vitest'
 
@@ -9,7 +9,9 @@ describe('config-no-runtime-code-in-build', () => {
   describe.runIf(isBuild)('build', () => {
     it('should not contain plugin code in build artifacts', async () => {
       await sleepForServerReady()
-      for await (const file of await glob(path.resolve(testDir, 'dist'), { onlyFiles: true })) {
+      const files = globSync('**', { cwd: path.resolve(testDir, 'dist'), absolute: true, onlyFiles: true })
+      expect(files.length).toBeGreaterThan(1)
+      for await (const file of files) {
         const content = await fs.promises.readFile(file, 'utf-8')
         expect(content).not.toContain('vite-plugin-checker')
       }


### PR DESCRIPTION
seems https://github.com/fi3ework/vite-plugin-checker/commit/ba9bbc8359c36905fafa0ab3eff751f669419966 caused a regression on windows tests (hanging)