### PR TITLE
fix: do not use `error` level for info/warn messages

### DIFF
--- a/packages/vite-plugin-checker/src/checkers/biome/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/biome/main.ts
@@ -58,7 +58,7 @@ const createDiagnostic: CreateDiagnostic<'biome'> = (pluginConfig) => {
 
         if (terminal) {
           for (const d of diagnostics) {
-            consoleLog(diagnosticToTerminalLog(d, 'Biome'))
+            consoleLog(diagnosticToTerminalLog(d, 'Biome'), 'info')
           }
 
           const errorCount = diagnostics.filter(
@@ -67,7 +67,10 @@ const createDiagnostic: CreateDiagnostic<'biome'> = (pluginConfig) => {
           const warningCount = diagnostics.filter(
             (d) => d.level === DiagnosticLevel.Warning,
           ).length
-          consoleLog(composeCheckerSummary('Biome', errorCount, warningCount))
+          consoleLog(
+            composeCheckerSummary('Biome', errorCount, warningCount),
+            errorCount ? 'error' : warningCount ? 'warn' : 'info',
+          )
         }
 
         if (overlay) {

--- a/packages/vite-plugin-checker/src/checkers/eslint/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/eslint/main.ts
@@ -91,7 +91,7 @@ const createDiagnostic: CreateDiagnostic<'eslint'> = (pluginConfig) => {
 
         if (terminal) {
           for (const d of diagnostics) {
-            consoleLog(diagnosticToTerminalLog(d, 'ESLint'))
+            consoleLog(diagnosticToTerminalLog(d, 'ESLint'), 'info')
           }
 
           const errorCount = diagnostics.filter(
@@ -100,7 +100,10 @@ const createDiagnostic: CreateDiagnostic<'eslint'> = (pluginConfig) => {
           const warningCount = diagnostics.filter(
             (d) => d.level === DiagnosticLevel.Warning,
           ).length
-          consoleLog(composeCheckerSummary('ESLint', errorCount, warningCount))
+          consoleLog(
+            composeCheckerSummary('ESLint', errorCount, warningCount),
+            errorCount ? 'error' : warningCount ? 'warn' : 'info',
+          )
         }
 
         if (overlay) {

--- a/packages/vite-plugin-checker/src/checkers/stylelint/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/stylelint/main.ts
@@ -63,7 +63,7 @@ const createDiagnostic: CreateDiagnostic<'stylelint'> = (pluginConfig) => {
 
         if (terminal) {
           for (const d of diagnostics) {
-            consoleLog(diagnosticToTerminalLog(d, 'Stylelint'))
+            consoleLog(diagnosticToTerminalLog(d, 'Stylelint'), 'info')
           }
 
           const errorCount = diagnostics.filter(
@@ -74,6 +74,7 @@ const createDiagnostic: CreateDiagnostic<'stylelint'> = (pluginConfig) => {
           ).length
           consoleLog(
             composeCheckerSummary('Stylelint', errorCount, warningCount),
+            errorCount ? 'error' : warningCount ? 'warn' : 'info',
           )
         }
 

--- a/packages/vite-plugin-checker/src/checkers/typescript/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/typescript/main.ts
@@ -124,6 +124,7 @@ const createDiagnostic: CreateDiagnostic<'typescript'> = (pluginConfig) => {
                     diagnostic.messageText.toString(),
                   ),
               ),
+              errorCount ? 'error' : 'info',
             )
           }
         })

--- a/packages/vite-plugin-checker/src/checkers/vls/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/vls/main.ts
@@ -38,7 +38,10 @@ export const createDiagnostic: CreateDiagnostic<'vls'> = (pluginConfig) => {
         (errorCount, warningCount) => {
           if (!terminal) return
 
-          consoleLog(composeCheckerSummary('VLS', errorCount, warningCount))
+          consoleLog(
+            composeCheckerSummary('VLS', errorCount, warningCount),
+            errorCount ? 'error' : warningCount ? 'warn' : 'info',
+          )
         }
 
       const onDispatchDiagnostics: DiagnosticOptions['onDispatchDiagnostics'] =
@@ -58,6 +61,7 @@ export const createDiagnostic: CreateDiagnostic<'vls'> = (pluginConfig) => {
               normalized
                 .map((d) => diagnosticToTerminalLog(d, 'VLS'))
                 .join(os.EOL),
+              'info',
             )
           }
         }

--- a/packages/vite-plugin-checker/src/checkers/vueTsc/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/vueTsc/main.ts
@@ -122,7 +122,7 @@ const createDiagnostic: CreateDiagnostic<'vueTsc'> = (pluginConfig) => {
 
             // TODO: only macOS will report multiple times for same result
             prevLogChunk = logChunk
-            consoleLog(logChunk)
+            consoleLog(logChunk, errorCount ? 'error' : 'info')
           }
         })
       }

--- a/packages/vite-plugin-checker/src/logger.ts
+++ b/packages/vite-plugin-checker/src/logger.ts
@@ -419,12 +419,13 @@ export function ensureCall(callback: CallableFunction) {
   })
 }
 
-export function consoleLog(value: string) {
+export function consoleLog(value: string, level: 'info' | 'warn' | 'error') {
   if (isMainThread) {
-    console.log(value)
+    console[level](value)
   } else {
     parentPort?.postMessage({
       type: ACTION_TYPES.console,
+      level: level,
       payload: value,
     })
   }

--- a/packages/vite-plugin-checker/src/main.ts
+++ b/packages/vite-plugin-checker/src/main.ts
@@ -201,7 +201,7 @@ export function checker(userConfig: UserPluginConfig): Plugin {
               // for test injection and customize logger in the future
               Checker.log(action)
             } else {
-              logger!.error(action.payload)
+              logger![action.level](action.payload)
             }
           }
         })

--- a/packages/vite-plugin-checker/src/types.ts
+++ b/packages/vite-plugin-checker/src/types.ts
@@ -260,6 +260,7 @@ export interface ConfigureServerAction extends AbstractAction {
 
 export interface ConsoleAction extends AbstractAction {
   type: ACTION_TYPES.console
+  level: 'info' | 'warn' | 'error'
   payload: string
 }
 


### PR DESCRIPTION
resolves https://github.com/fi3ework/vite-plugin-checker/issues/238