### PR TITLE
feat: add `watchPath` option to resolve EMFILE errors

### DIFF
--- a/docs/checkers/eslint.md
+++ b/docs/checkers/eslint.md
@@ -47,8 +47,11 @@ export default {
     checker({
       eslint: {
         lintCommand: 'eslint "./src/**/*.{ts,tsx}"',
-        // Only watch files in the src directory
+        // Single directory
         watchPath: './src',
+        
+        // Multiple directories
+        // watchPath: ['./src', './lib'],
       },
     }),
   ],
@@ -62,7 +65,7 @@ Advanced object configuration table of `options.eslint`
 | field              | Type                                                                                                       | Default value          | Description                                                                                                                                                                                                              |
 | :----------------- | ---------------------------------------------------------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | lintCommand        | `string`                                                                                                   | This value is required | `lintCommand` will be executed at build mode, and will also be used as default config for dev mode when `eslint.dev.eslint` is nullable.                                                                                 |
-| watchPath          | `string`                                                                                                   | `undefined`            | **(Only in dev mode)** Configure path to watch files for ESLint. If not specified, will watch the entire project root. Use this to improve performance and avoid `EMFILE: too many open files` errors.              |
+| watchPath          | `string \| string[]`                                                                                       | `undefined`            | **(Only in dev mode)** Configure path to watch files for ESLint. If not specified, will watch the entire project root. Use this to improve performance and avoid `EMFILE: too many open files` errors.              |
 | useFlatConfig      | `boolean`                                                                                                  | `false`                | If `true`, the plugin will use the new [flat config](https://eslint.org/docs/latest/use/configure/configuration-files-new) of ESLint.                                                                                    |
 | dev.overrideConfig | [`ESLint.Options`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/eslint/index.d.ts) | `undefined`            | **(Only in dev mode)** You can override the options of the translated from `lintCommand`. Config priority: `const eslint = new ESLint({cwd: root, ...translatedOptions, ...pluginConfig.eslint.dev?.overrideConfig, })`. |
 | dev.logLevel       | `('error' \| 'warning')[]`                                                                                 | `['error', 'warning']` | **(Only in dev mode)** Which level of ESLint should be emitted to terminal and overlay in dev mode                                                                                                                       |

--- a/docs/checkers/eslint.md
+++ b/docs/checkers/eslint.md
@@ -37,6 +37,24 @@ export default {
 }
 ```
 
+### Performance Optimization
+
+If you're experiencing `EMFILE: too many open files` errors or want to improve performance, you can use the `watchPath` option to limit file watching to specific directories:
+
+```js
+export default {
+  plugins: [
+    checker({
+      eslint: {
+        lintCommand: 'eslint "./src/**/*.{ts,tsx}"',
+        // Only watch files in the src directory
+        watchPath: './src',
+      },
+    }),
+  ],
+}
+```
+
 ## Configuration
 
 Advanced object configuration table of `options.eslint`
@@ -44,6 +62,7 @@ Advanced object configuration table of `options.eslint`
 | field              | Type                                                                                                       | Default value          | Description                                                                                                                                                                                                              |
 | :----------------- | ---------------------------------------------------------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | lintCommand        | `string`                                                                                                   | This value is required | `lintCommand` will be executed at build mode, and will also be used as default config for dev mode when `eslint.dev.eslint` is nullable.                                                                                 |
+| watchPath          | `string`                                                                                                   | `undefined`            | **(Only in dev mode)** Configure path to watch files for ESLint. If not specified, will watch the entire project root. Use this to improve performance and avoid `EMFILE: too many open files` errors.              |
 | useFlatConfig      | `boolean`                                                                                                  | `false`                | If `true`, the plugin will use the new [flat config](https://eslint.org/docs/latest/use/configure/configuration-files-new) of ESLint.                                                                                    |
 | dev.overrideConfig | [`ESLint.Options`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/eslint/index.d.ts) | `undefined`            | **(Only in dev mode)** You can override the options of the translated from `lintCommand`. Config priority: `const eslint = new ESLint({cwd: root, ...translatedOptions, ...pluginConfig.eslint.dev?.overrideConfig, })`. |
 | dev.logLevel       | `('error' \| 'warning')[]`                                                                                 | `['error', 'warning']` | **(Only in dev mode)** Which level of ESLint should be emitted to terminal and overlay in dev mode                                                                                                                       |

--- a/docs/checkers/stylelint.md
+++ b/docs/checkers/stylelint.md
@@ -38,8 +38,11 @@ export default {
     checker({
       stylelint: {
         lintCommand: 'stylelint ./src/**/*.{css,vue}',
-        // Only watch files in the src directory
+        // Single directory
         watchPath: './src',
+        
+        // Multiple directories
+        // watchPath: ['./src', './components'],
       },
     }),
   ],
@@ -53,6 +56,6 @@ Advanced object configuration table of `options.stylelint`
 | field              | Type                                                                                                     | Default value          | Description                                                                                                                                                                                                       |
 | :----------------- | -------------------------------------------------------------------------------------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | lintCommand        | `string`                                                                                                 | This value is required | `lintCommand` will be executed at build mode, and will also be used as default config for dev mode when `stylelint.dev.stylelint` is nullable.                                                                    |
-| watchPath          | `string`                                                                                                 | `undefined`            | **(Only in dev mode)** Configure path to watch files for Stylelint. If not specified, will watch the entire project root. Use this to improve performance and avoid `EMFILE: too many open files` errors.    |
+| watchPath          | `string \| string[]`                                                                                     | `undefined`            | **(Only in dev mode)** Configure path to watch files for Stylelint. If not specified, will watch the entire project root. Use this to improve performance and avoid `EMFILE: too many open files` errors.    |
 | dev.overrideConfig | [`Stylelint.LinterOptions`](https://github.com/stylelint/stylelint/blob/main/types/stylelint/index.d.ts) | `undefined`            | **(Only in dev mode)** You can override the options of the translated from `lintCommand`. Config priority: `stylelint.lint({ cwd: root, ...translatedOptions, ...pluginConfig.stylelint.dev?.overrideConfig, })`. |
 | dev.logLevel       | `('error' \| 'warning')[]`                                                                               | `['error', 'warning']` | **(Only in dev mode)** Which level of Stylelint should be emitted to terminal and overlay in dev mode                                                                                                             |

--- a/docs/checkers/stylelint.md
+++ b/docs/checkers/stylelint.md
@@ -28,6 +28,24 @@
    }
    ```
 
+### Performance Optimization
+
+If you're experiencing `EMFILE: too many open files` errors or want to improve performance, you can use the `watchPath` option to limit file watching to specific directories:
+
+```js
+export default {
+  plugins: [
+    checker({
+      stylelint: {
+        lintCommand: 'stylelint ./src/**/*.{css,vue}',
+        // Only watch files in the src directory
+        watchPath: './src',
+      },
+    }),
+  ],
+}
+```
+
 ## Configuration
 
 Advanced object configuration table of `options.stylelint`
@@ -35,5 +53,6 @@ Advanced object configuration table of `options.stylelint`
 | field              | Type                                                                                                     | Default value          | Description                                                                                                                                                                                                       |
 | :----------------- | -------------------------------------------------------------------------------------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | lintCommand        | `string`                                                                                                 | This value is required | `lintCommand` will be executed at build mode, and will also be used as default config for dev mode when `stylelint.dev.stylelint` is nullable.                                                                    |
+| watchPath          | `string`                                                                                                 | `undefined`            | **(Only in dev mode)** Configure path to watch files for Stylelint. If not specified, will watch the entire project root. Use this to improve performance and avoid `EMFILE: too many open files` errors.    |
 | dev.overrideConfig | [`Stylelint.LinterOptions`](https://github.com/stylelint/stylelint/blob/main/types/stylelint/index.d.ts) | `undefined`            | **(Only in dev mode)** You can override the options of the translated from `lintCommand`. Config priority: `stylelint.lint({ cwd: root, ...translatedOptions, ...pluginConfig.stylelint.dev?.overrideConfig, })`. |
 | dev.logLevel       | `('error' \| 'warning')[]`                                                                               | `['error', 'warning']` | **(Only in dev mode)** Which level of Stylelint should be emitted to terminal and overlay in dev mode                                                                                                             |

--- a/packages/vite-plugin-checker/src/checkers/eslint/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/eslint/main.ts
@@ -155,13 +155,20 @@ const createDiagnostic: CreateDiagnostic<'eslint'> = (pluginConfig) => {
       dispatchDiagnostics()
 
       // watch lint
-      const watchTarget = pluginConfig.eslint.watchPath 
-        ? path.resolve(root, pluginConfig.eslint.watchPath)
-        : root
-        
+      let watchTarget: string | string[] = root
+      if (pluginConfig.eslint.watchPath) {
+        if (Array.isArray(pluginConfig.eslint.watchPath)) {
+          watchTarget = pluginConfig.eslint.watchPath.map((p) =>
+            path.resolve(root, p),
+          )
+        } else {
+          watchTarget = path.resolve(root, pluginConfig.eslint.watchPath)
+        }
+      }
+
       const watcher = chokidar.watch(watchTarget, {
         cwd: root,
-        ignored: [createIgnore(root, files)],
+        ignored: createIgnore(root, files),
       })
 
       watcher.on('change', async (filePath) => {

--- a/packages/vite-plugin-checker/src/checkers/eslint/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/eslint/main.ts
@@ -155,9 +155,13 @@ const createDiagnostic: CreateDiagnostic<'eslint'> = (pluginConfig) => {
       dispatchDiagnostics()
 
       // watch lint
-      const watcher = chokidar.watch(root, {
+      const watchTarget = pluginConfig.eslint.watchPath 
+        ? path.resolve(root, pluginConfig.eslint.watchPath)
+        : root
+        
+      const watcher = chokidar.watch(watchTarget, {
         cwd: root,
-        ignored: createIgnore(root, files),
+        ignored: [createIgnore(root, files)],
       })
 
       watcher.on('change', async (filePath) => {

--- a/packages/vite-plugin-checker/src/checkers/stylelint/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/stylelint/main.ts
@@ -127,7 +127,11 @@ const createDiagnostic: CreateDiagnostic<'stylelint'> = (pluginConfig) => {
       dispatchDiagnostics()
 
       // watch lint
-      const watcher = chokidar.watch(root, {
+      const watchTarget = pluginConfig.stylelint.watchPath 
+        ? path.resolve(root, pluginConfig.stylelint.watchPath)
+        : root
+
+      const watcher = chokidar.watch(watchTarget, {
         cwd: root,
         ignored: createIgnore(root, translatedOptions.files),
       })

--- a/packages/vite-plugin-checker/src/checkers/stylelint/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/stylelint/main.ts
@@ -127,9 +127,16 @@ const createDiagnostic: CreateDiagnostic<'stylelint'> = (pluginConfig) => {
       dispatchDiagnostics()
 
       // watch lint
-      const watchTarget = pluginConfig.stylelint.watchPath 
-        ? path.resolve(root, pluginConfig.stylelint.watchPath)
-        : root
+      let watchTarget: string | string[] = root
+      if (pluginConfig.stylelint.watchPath) {
+        if (Array.isArray(pluginConfig.stylelint.watchPath)) {
+          watchTarget = pluginConfig.stylelint.watchPath.map((p) =>
+            path.resolve(root, p),
+          )
+        } else {
+          watchTarget = path.resolve(root, pluginConfig.stylelint.watchPath)
+        }
+      }
 
       const watcher = chokidar.watch(watchTarget, {
         cwd: root,

--- a/packages/vite-plugin-checker/src/types.ts
+++ b/packages/vite-plugin-checker/src/types.ts
@@ -54,7 +54,7 @@ export type EslintConfig =
       /**
        * Configure path to watch files
        */
-      watchPath?: string
+      watchPath?: string | string[]
       /**
        * lintCommand will be executed at build mode, and will also be used as
        * default config for dev mode when options.eslint.dev.eslint is nullable.

--- a/packages/vite-plugin-checker/src/types.ts
+++ b/packages/vite-plugin-checker/src/types.ts
@@ -52,6 +52,10 @@ export type EslintConfig =
   | false
   | {
       /**
+       * Configure path to watch files
+       */
+      watchPath?: string
+      /**
        * lintCommand will be executed at build mode, and will also be used as
        * default config for dev mode when options.eslint.dev.eslint is nullable.
        */
@@ -72,6 +76,10 @@ export type EslintConfig =
 export type StylelintConfig =
   | false
   | {
+      /**
+       * Configure path to watch files
+       */
+      watchPath?: string
       /**
        * lintCommand will be executed at build mode, and will also be used as
        * default config for dev mode when options.stylelint.dev.stylelint is nullable.

--- a/packages/vite-plugin-checker/src/types.ts
+++ b/packages/vite-plugin-checker/src/types.ts
@@ -79,7 +79,7 @@ export type StylelintConfig =
       /**
        * Configure path to watch files
        */
-      watchPath?: string
+      watchPath?: string | string[]
       /**
        * lintCommand will be executed at build mode, and will also be used as
        * default config for dev mode when options.stylelint.dev.stylelint is nullable.


### PR DESCRIPTION
Fixes #511

This happens because chokidar watches the entire project root directory, leading to excessive file handle usage in large projects.

Added a new `watchPath` option for ESLint (and Stylelint) checkers that allows users to specify a specific directory to watch instead of the entire project root.

**Key Changes:**
1. **New Configuration Option**: Added `watchPath?: string` to ESLint and Stylelint type definitions
2. **Targeted File Watching**: When `watchPath` is specified, chokidar only watches that specific directory
3. **Backward Compatibility**: When `watchPath` is not specified, behaves exactly as before (watches entire root)
4. **Documentation**: Added examples and performance optimization guides
