### PR TITLE
Fix node 24 deprecation with `spawn()` args (fixes #535)

### DIFF
--- a/packages/vite-plugin-checker/src/main.ts
+++ b/packages/vite-plugin-checker/src/main.ts
@@ -244,7 +244,10 @@ function spawnChecker(
     const finalBin: BuildCheckBinStr =
       typeof buildBin === 'function' ? buildBin(userConfig) : buildBin
 
-    const proc = spawn(...finalBin, {
+    const [command, args] = finalBin
+    const commandWithArgs = [command, ...args].join(' ')
+
+    const proc = spawn(commandWithArgs, {
       cwd: process.cwd(),
       stdio: 'inherit',
       env: localEnv,


### PR DESCRIPTION
Fixes #535 
```
[DEP0190] DeprecationWarning:  Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
```