### PR TITLE
feat: Use external scripts instead of inline scripts.

### DIFF
--- a/packages/vite-plugin-checker/src/main.ts
+++ b/packages/vite-plugin-checker/src/main.ts
@@ -148,8 +148,7 @@ export function checker(userConfig: UserPluginConfig): Plugin {
       return [
         {
           tag: 'script',
-          attrs: { type: 'module' },
-          children: composePreambleCode({ baseWithOrigin, overlayConfig }),
+          attrs: { type: 'module', src: RUNTIME_CLIENT_ENTRY_PATH },
         },
       ]
     },


### PR DESCRIPTION
This change makes it work correctly even if the [`Content-Security-Policy: script-src directive`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/script-src) is not set to `'unsafe-inline'`.