### PR TITLE
feat: Add `watchPath` option to Biome checker 

### DIFF
--- a/docs/checkers/biome.md
+++ b/docs/checkers/biome.md
@@ -31,6 +31,7 @@ Advanced object configuration table of `options.biome`
 | :------------ | --------------------------------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
 | command       | `'check' \| 'lint' \| 'format' \| 'ci'` | `'lint'` in dev, `'check'` in build. | The command to execute biome with.                                                                             |
 | flags         | `string`                                | `''`                                 | CLI flags to pass to the command.                                                                              |
+| watchPath     | `string \| string[]`                    | `undefined`                          | **(Only in dev mode)** Configure path to watch files for Biome. If not specified, will watch the entire project root. |
 | dev.logLevel  | `('error' \| 'warning')[]`              | `['error', 'warning']`               | **(Only in dev mode)** Which level of Biome diagnostics should be emitted to terminal and overlay in dev mode. |
 | dev.command   | `'check' \| 'lint' \| 'format' \| 'ci'` | `''`                                 | Command to run in dev mode, it will override `command` config in dev mode.                                     |
 | dev.flags     | `string`                                | `''`                                 | Flags to run in dev mode, it will override `flags` config in dev mode.                                         |

--- a/packages/vite-plugin-checker/src/checkers/biome/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/biome/main.ts
@@ -121,7 +121,16 @@ const createDiagnostic: CreateDiagnostic<'biome'> = (pluginConfig) => {
       dispatchDiagnostics()
 
       // watch lint
-      const watcher = chokidar.watch([], {
+      let watchTarget: string | string[] = root
+      if (typeof biomeConfig === 'object' && biomeConfig.watchPath) {
+        if (Array.isArray(biomeConfig.watchPath)) {
+          watchTarget = biomeConfig.watchPath.map((p) => path.resolve(root, p))
+        } else {
+          watchTarget = path.resolve(root, biomeConfig.watchPath)
+        }
+      }
+
+      const watcher = chokidar.watch(watchTarget, {
         cwd: root,
         ignored: (path: string) => path.includes('node_modules'),
       })
@@ -131,7 +140,6 @@ const createDiagnostic: CreateDiagnostic<'biome'> = (pluginConfig) => {
       watcher.on('unlink', async (filePath) => {
         handleFileChange(filePath, 'unlink')
       })
-      watcher.add('.')
     },
   }
 }

--- a/packages/vite-plugin-checker/src/types.ts
+++ b/packages/vite-plugin-checker/src/types.ts
@@ -108,6 +108,10 @@ export type BiomeConfig =
        * or `build.command` is set their mode.
        * */
       flags?: string
+      /**
+       * Configure path to watch files
+       */
+      watchPath?: string | string[]
       dev?: Partial<{
         /** Command will be used in dev mode */
         command: BiomeCommand


### PR DESCRIPTION
## Summary

Add `watchPath` option to Biome checker to allow users to specify which directories should be watched for file changes in dev mode.

## Motivation

When using Panda CSS, Biome watches the entire project including the `styled-system` directory (Panda CSS's default output directory). Since this directory contains auto-generated files, every change triggers unnecessary Biome checks, causing performance issues.

This feature brings Biome to parity with ESLint, Stylelint, and oxlint checkers, which already support `watchPath`.

## Changes

- Add `watchPath` option to `BiomeConfig` type (`string | string[]`)
- Implement watchTarget resolution logic in biome checker (follows same pattern as ESLint/Stylelint/oxlint)
- Update chokidar configuration to watch specified paths instead of entire root
- Remove redundant `watcher.add('.')` call
- Update documentation

## Usage

```js
import checker from 'vite-plugin-checker'

export default {
  plugins: [
    checker({
      biome: {
        // Exclude styled-system directory
        watchPath: 'src'
      }
    })
  ]
}

// Multiple directories
checker({
  biome: {
    watchPath: ['src', 'lib']
  }
})