### PR TITLE
fix(oxlint): normalize path not handling file://

### DIFF
--- a/packages/vite-plugin-checker/src/sources.ts
+++ b/packages/vite-plugin-checker/src/sources.ts
@@ -3,6 +3,10 @@ import path from 'node:path'
 
 export function normalizePath(p: string, cwd: string) {
   let filename = p
+  // Strip file:// URL scheme (oxlint outputs file:// URLs in JSON format)
+  if (filename && filename.startsWith("file://")) {
+    filename = filename.slice(7);
+  }
   if (filename) {
     filename = path.isAbsolute(filename)
       ? filename


### PR DESCRIPTION
This caused errors of oxlint to not being reported due to missing handling of file:// protocol in read sources.