### PR TITLE
fix(tsc): force `noEmit` when `tsconfig.json` can't be parsed

### DIFF
--- a/packages/vite-plugin-checker/__tests__/tscUtils.spec.ts
+++ b/packages/vite-plugin-checker/__tests__/tscUtils.spec.ts
@@ -30,7 +30,7 @@ describe('forceNoEmitOnSolutionBuilderHost', () => {
   }
 
   it('leaves a well-formed referenced project untouched', () => {
-    const refPath = path.join(tmp, 'tsconfig.app.json')
+    const refPath = path.posix.join(tmp, 'tsconfig.app.json')
     fs.writeFileSync(
       refPath,
       JSON.stringify({
@@ -38,7 +38,7 @@ describe('forceNoEmitOnSolutionBuilderHost', () => {
         include: ['main.ts'],
       }),
     )
-    fs.writeFileSync(path.join(tmp, 'main.ts'), 'export const x = 1\n')
+    fs.writeFileSync(path.posix.join(tmp, 'main.ts'), 'export const x = 1\n')
 
     const host = forceNoEmitOnSolutionBuilderHost(ts, makeHost())
     const parsed = host.getParsedCommandLine!(refPath)
@@ -53,12 +53,12 @@ describe('forceNoEmitOnSolutionBuilderHost', () => {
   it('returns undefined for a missing referenced project', () => {
     const host = forceNoEmitOnSolutionBuilderHost(ts, makeHost())
     expect(
-      host.getParsedCommandLine!(path.join(tmp, 'does-not-exist.json')),
+      host.getParsedCommandLine!(path.posix.join(tmp, 'does-not-exist.json')),
     ).toBeUndefined()
   })
 
   it('forces noEmit even when the referenced project is empty', () => {
-    const refPath = path.join(tmp, 'tsconfig.app.json')
+    const refPath = path.posix.join(tmp, 'tsconfig.app.json')
     fs.writeFileSync(refPath, '')
 
     const host = forceNoEmitOnSolutionBuilderHost(ts, makeHost())
@@ -69,7 +69,7 @@ describe('forceNoEmitOnSolutionBuilderHost', () => {
   })
 
   it('forces noEmit even when the referenced project is partial JSON', () => {
-    const refPath = path.join(tmp, 'tsconfig.app.json')
+    const refPath = path.posix.join(tmp, 'tsconfig.app.json')
     fs.writeFileSync(refPath, '{\n  "compilerOptions": {')
 
     const host = forceNoEmitOnSolutionBuilderHost(ts, makeHost())

--- a/packages/vite-plugin-checker/__tests__/tscUtils.spec.ts
+++ b/packages/vite-plugin-checker/__tests__/tscUtils.spec.ts
@@ -1,0 +1,73 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import ts from 'typescript'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { forceNoEmitOnSolutionBuilderHost } from '../src/checkers/tscUtils'
+
+describe('forceNoEmitOnSolutionBuilderHost', () => {
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vpc-tscutils-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  function makeHost() {
+    return ts.createSolutionBuilderWithWatchHost(
+      ts.sys,
+      ts.createEmitAndSemanticDiagnosticsBuilderProgram,
+    )
+  }
+
+  it('forces noEmit on a well-formed referenced project', () => {
+    const refPath = path.join(tmp, 'tsconfig.app.json')
+    fs.writeFileSync(
+      refPath,
+      JSON.stringify({
+        compilerOptions: { target: 'ESNext', noEmit: false, composite: true },
+        include: ['main.ts'],
+      }),
+    )
+    fs.writeFileSync(path.join(tmp, 'main.ts'), 'export const x = 1\n')
+
+    const host = forceNoEmitOnSolutionBuilderHost(ts, makeHost())
+    const parsed = host.getParsedCommandLine!(refPath)
+
+    expect(parsed).toBeDefined()
+    expect(parsed!.options.noEmit).toBe(true)
+  })
+
+  it('returns undefined for a missing referenced project', () => {
+    const host = forceNoEmitOnSolutionBuilderHost(ts, makeHost())
+    expect(
+      host.getParsedCommandLine!(path.join(tmp, 'does-not-exist.json')),
+    ).toBeUndefined()
+  })
+
+  it('forces noEmit even when the referenced project is empty', () => {
+    const refPath = path.join(tmp, 'tsconfig.app.json')
+    fs.writeFileSync(refPath, '')
+
+    const host = forceNoEmitOnSolutionBuilderHost(ts, makeHost())
+    const parsed = host.getParsedCommandLine!(refPath)
+
+    expect(parsed).toBeDefined()
+    expect(parsed!.options.noEmit).toBe(true)
+  })
+
+  it('forces noEmit even when the referenced project is partial JSON', () => {
+    const refPath = path.join(tmp, 'tsconfig.app.json')
+    fs.writeFileSync(refPath, '{\n  "compilerOptions": {')
+
+    const host = forceNoEmitOnSolutionBuilderHost(ts, makeHost())
+    const parsed = host.getParsedCommandLine!(refPath)
+
+    expect(parsed).toBeDefined()
+    expect(parsed!.options.noEmit).toBe(true)
+  })
+})

--- a/packages/vite-plugin-checker/__tests__/tscUtils.spec.ts
+++ b/packages/vite-plugin-checker/__tests__/tscUtils.spec.ts
@@ -10,7 +10,12 @@ describe('forceNoEmitOnSolutionBuilderHost', () => {
   let tmp: string
 
   beforeEach(() => {
-    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vpc-tscutils-'))
+    // forward slashes match what TS's canonical file names look like; using a
+    // mixed-slash path on Windows trips an internal TS Debug.assert when it
+    // attaches diagnostics to a failed parse.
+    tmp = fs
+      .mkdtempSync(path.join(os.tmpdir(), 'vpc-tscutils-'))
+      .replace(/\\/g, '/')
   })
 
   afterEach(() => {
@@ -24,7 +29,7 @@ describe('forceNoEmitOnSolutionBuilderHost', () => {
     )
   }
 
-  it('forces noEmit on a well-formed referenced project', () => {
+  it('leaves a well-formed referenced project untouched', () => {
     const refPath = path.join(tmp, 'tsconfig.app.json')
     fs.writeFileSync(
       refPath,
@@ -39,7 +44,10 @@ describe('forceNoEmitOnSolutionBuilderHost', () => {
     const parsed = host.getParsedCommandLine!(refPath)
 
     expect(parsed).toBeDefined()
-    expect(parsed!.options.noEmit).toBe(true)
+    expect(parsed!.errors).toHaveLength(0)
+    // a valid composite referenced project must be allowed to emit; forcing
+    // noEmit here would break `tsc --build` invariants.
+    expect(parsed!.options.noEmit).toBe(false)
   })
 
   it('returns undefined for a missing referenced project', () => {

--- a/packages/vite-plugin-checker/src/checkers/tscUtils.ts
+++ b/packages/vite-plugin-checker/src/checkers/tscUtils.ts
@@ -1,16 +1,20 @@
 import type ts from 'typescript'
 
 /**
- * Wrap a `SolutionBuilderWithWatchHost` so every parsed referenced project has
- * `compilerOptions.noEmit` forced to `true`.
+ * Wrap a `SolutionBuilderWithWatchHost` so that when a referenced project's
+ * tsconfig fails to parse, we force `compilerOptions.noEmit` to `true` instead
+ * of letting TS fall back to defaults (which include `noEmit: false`).
  *
  * `createSolutionBuilderWithWatch` takes its emit decisions from each referenced
  * project's own `compilerOptions`. If a referenced tsconfig is truncated or
  * mid-write at the moment TS reads it (which can happen e.g. when a dev tool
  * rewrites tsconfigs at runtime), TS falls back to default options — and the
  * default is `noEmit: false`, so the build host writes `.js` files next to
- * sources. The non-buildMode branch hard-codes `noEmit: true`; this keeps
- * buildMode consistent. See https://github.com/nuxt/nuxt/issues/32872.
+ * sources. See https://github.com/nuxt/nuxt/issues/32872.
+ *
+ * We deliberately only override when parsing produced errors: forcing
+ * `noEmit: true` on every parsed project would break valid `tsc --build`
+ * graphs, since composite referenced projects must emit declarations.
  */
 export function forceNoEmitOnSolutionBuilderHost<
   H extends {
@@ -36,7 +40,7 @@ export function forceNoEmitOnSolutionBuilderHost<
           undefined,
           parseConfigHost,
         )
-    if (parsed) {
+    if (parsed && parsed.errors.length > 0) {
       parsed.options.noEmit = true
     }
     return parsed

--- a/packages/vite-plugin-checker/src/checkers/tscUtils.ts
+++ b/packages/vite-plugin-checker/src/checkers/tscUtils.ts
@@ -1,0 +1,46 @@
+import type ts from 'typescript'
+
+/**
+ * Wrap a `SolutionBuilderWithWatchHost` so every parsed referenced project has
+ * `compilerOptions.noEmit` forced to `true`.
+ *
+ * `createSolutionBuilderWithWatch` takes its emit decisions from each referenced
+ * project's own `compilerOptions`. If a referenced tsconfig is truncated or
+ * mid-write at the moment TS reads it (which can happen e.g. when a dev tool
+ * rewrites tsconfigs at runtime), TS falls back to default options — and the
+ * default is `noEmit: false`, so the build host writes `.js` files next to
+ * sources. The non-buildMode branch hard-codes `noEmit: true`; this keeps
+ * buildMode consistent. See https://github.com/nuxt/nuxt/issues/32872.
+ */
+export function forceNoEmitOnSolutionBuilderHost<
+  H extends {
+    getParsedCommandLine?: ts.SolutionBuilderHostBase<ts.BuilderProgram>['getParsedCommandLine']
+  },
+>(ts: typeof import('typescript'), host: H): H {
+  const parseConfigHost: ts.ParseConfigFileHost = {
+    useCaseSensitiveFileNames: ts.sys.useCaseSensitiveFileNames,
+    readDirectory: ts.sys.readDirectory,
+    fileExists: ts.sys.fileExists,
+    readFile: ts.sys.readFile,
+    getCurrentDirectory: ts.sys.getCurrentDirectory,
+    onUnRecoverableConfigFileDiagnostic: () => {},
+  }
+
+  const original = host.getParsedCommandLine?.bind(host)
+
+  host.getParsedCommandLine = (fileName: string) => {
+    const parsed = original
+      ? original(fileName)
+      : ts.getParsedCommandLineOfConfigFile(
+          fileName,
+          undefined,
+          parseConfigHost,
+        )
+    if (parsed) {
+      parsed.options.noEmit = true
+    }
+    return parsed
+  }
+
+  return host
+}

--- a/packages/vite-plugin-checker/src/checkers/typescript/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/typescript/main.ts
@@ -21,6 +21,7 @@ import {
   type CreateDiagnostic,
   type DiagnosticToRuntime,
 } from '../../types.js'
+import { forceNoEmitOnSolutionBuilderHost } from '../tscUtils.js'
 
 const __filename = fileURLToPath(import.meta.url)
 let createServeAndBuild: any
@@ -140,12 +141,15 @@ const createDiagnostic: CreateDiagnostic<'typescript'> = (pluginConfig) => {
         typeof pluginConfig.typescript === 'object' &&
         pluginConfig.typescript.buildMode
       ) {
-        const host = ts.createSolutionBuilderWithWatchHost(
-          ts.sys,
-          createProgram,
-          reportDiagnostic,
-          undefined,
-          reportWatchStatusChanged,
+        const host = forceNoEmitOnSolutionBuilderHost(
+          ts,
+          ts.createSolutionBuilderWithWatchHost(
+            ts.sys,
+            createProgram,
+            reportDiagnostic,
+            undefined,
+            reportWatchStatusChanged,
+          ),
         )
 
         ts.createSolutionBuilderWithWatch(host, [configFile], {}).build()

--- a/packages/vite-plugin-checker/src/checkers/vueTsc/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/vueTsc/main.ts
@@ -21,6 +21,7 @@ import {
   type CreateDiagnostic,
   type DiagnosticToRuntime,
 } from '../../types.js'
+import { forceNoEmitOnSolutionBuilderHost } from '../tscUtils.js'
 import { prepareVueTsc } from './prepareVueTsc.js'
 
 const _require = createRequire(import.meta.url)
@@ -135,12 +136,15 @@ const createDiagnostic: CreateDiagnostic<'vueTsc'> = (pluginConfig) => {
         typeof pluginConfig.vueTsc === 'object' &&
         pluginConfig.vueTsc.buildMode
       ) {
-        const host = vueTs.createSolutionBuilderWithWatchHost(
-          vueTs.sys,
-          createProgram,
-          reportDiagnostic,
-          undefined,
-          reportWatchStatusChanged,
+        const host = forceNoEmitOnSolutionBuilderHost(
+          vueTs,
+          vueTs.createSolutionBuilderWithWatchHost(
+            vueTs.sys,
+            createProgram,
+            reportDiagnostic,
+            undefined,
+            reportWatchStatusChanged,
+          ),
         )
 
         vueTs.createSolutionBuilderWithWatch(host, [configFile], {}).build()


### PR DESCRIPTION
resolves https://github.com/nuxt/nuxt/issues/32872

cc: @cernymatej

this wraps the solution builder host's `getParsedCommandLine` and forces `noEmit: true` only when parsing produced errors. A well-formed referenced project is left untouched, since composite referenced projects must be allowed to emit declarations for `tsc --build` to work.