### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,1 @@
 registry=https://registry.npmjs.org/
-auto-install-peers=false
-hoist=false
-shell-emulator=true

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
     "vite": "^8.0.9",
     "vitest": "^3.2.4"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@11.1.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,14 @@ packages:
   - 'playground/**'
   - 'packages/*'
   - 'docs'
+
+allowBuilds:
+  esbuild: false
+  playwright-chromium: false
+  simple-git-hooks: false
+
+autoInstallPeers: false
+
+hoist: false
+
+shellEmulator: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,4 +12,8 @@ autoInstallPeers: false
 
 hoist: false
 
+publicHoistPattern:
+  - '*eslint*'
+  - '*prettier*'
+
 shellEmulator: true


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`