### PR TITLE
fix: show error overlay in SSR setups that resolve the config twice

### DIFF
--- a/packages/vite-plugin-checker/src/main.ts
+++ b/packages/vite-plugin-checker/src/main.ts
@@ -142,7 +142,6 @@ export function checker(userConfig: UserPluginConfig): Plugin {
       return
     },
     transformIndexHtml() {
-      if (initialized) return
       if (isProduction) return
 
       return [

--- a/playground/config-overlay-ssr/__tests__/test.spec.ts
+++ b/playground/config-overlay-ssr/__tests__/test.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { diagnostics, getHmrOverlayText, isServe, sleepForServerReady, stripedLog } from '../../testUtils'
+
+// Regression test for https://github.com/fi3ework/vite-plugin-checker/issues/733
+
+describe('config-overlay-ssr', () => {
+  describe.runIf(isServe)('serve', () => {
+    it('still reports the TypeScript error to the terminal', async () => {
+      await sleepForServerReady()
+      expect(stripedLog.join('\n')).toContain('TS2322')
+      expect(diagnostics.length).toBeGreaterThan(0)
+    })
+
+    it('shows the error overlay in the browser', async () => {
+      await sleepForServerReady()
+      const [message, file] = await getHmrOverlayText()
+      expect(message).toContain(`Type 'string' is not assignable to type 'number'.`)
+      expect(file).toContain('src/main.ts')
+    })
+  })
+})

--- a/playground/config-overlay-ssr/package.json
+++ b/playground/config-overlay-ssr/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@playground/config-overlay-ssr",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "node serve.js",
+    "serve": "vite preview"
+  },
+  "devDependencies": {
+    "express": "^5.2.1",
+    "typescript": "^5.8.3",
+    "vite": "^8.0.9",
+    "vite-plugin-checker": "workspace:*"
+  }
+}

--- a/playground/config-overlay-ssr/root/index.html
+++ b/playground/config-overlay-ssr/root/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>https://github.com/fi3ework/vite-plugin-checker/issues/733</title>
+    </head>
+    <body>
+        <div id="root"></div>
+        <script type="module" src="/src/main.ts"></script>
+    </body>
+</html>

--- a/playground/config-overlay-ssr/root/src/main.ts
+++ b/playground/config-overlay-ssr/root/src/main.ts
@@ -1,0 +1,9 @@
+import { text } from './text'
+
+// Intentional type error: `string` is not assignable to `number` (TS2322).
+const hello: number = 'Hello'
+
+const rootDom = document.querySelector('#root')! as HTMLElement
+rootDom.innerHTML = hello + text
+
+export {}

--- a/playground/config-overlay-ssr/root/src/text.ts
+++ b/playground/config-overlay-ssr/root/src/text.ts
@@ -1,0 +1,1 @@
+export const text = 'https://github.com/fi3ework/vite-plugin-checker/issues/733'

--- a/playground/config-overlay-ssr/root/tsconfig.json
+++ b/playground/config-overlay-ssr/root/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "types": ["vite/client"],
+    "allowJs": false,
+    "skipLibCheck": false,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./src"]
+}

--- a/playground/config-overlay-ssr/serve.js
+++ b/playground/config-overlay-ssr/serve.js
@@ -1,0 +1,73 @@
+import fs from 'node:fs'
+import http from 'node:http'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import express from 'express'
+import { createServer as createViteServer, resolveConfig } from 'vite'
+import checker from 'vite-plugin-checker'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const root = path.resolve(__dirname, 'root')
+
+export const port = 3009
+export let viteServer
+
+export async function serve() {
+  const plugins = [checker({ typescript: true, overlay: true })]
+
+  const app = express()
+  const httpServer = http.createServer(app)
+
+  const viteDevServer = await createViteServer({
+    root,
+    configFile: false,
+    appType: 'custom',
+    server: { middlewareMode: true, hmr: { server: httpServer } },
+    plugins,
+  })
+  viteServer = viteDevServer
+
+  await resolveConfig({ root, configFile: false, plugins }, 'serve')
+
+  viteDevServer.listen = async () => viteDevServer
+  const closeViteDevServer = viteDevServer.close.bind(viteDevServer)
+  viteDevServer.close = async () => {
+    await new Promise((resolve) => httpServer.close(resolve))
+    await closeViteDevServer()
+  }
+
+  app.use(viteDevServer.middlewares)
+
+  app.use(async (req, res, next) => {
+    try {
+      const template = fs.readFileSync(path.resolve(root, 'index.html'), 'utf-8')
+      const html = await viteDevServer.transformIndexHtml(req.originalUrl, template)
+      res.status(200).set({ 'Content-Type': 'text/html' }).send(html)
+    } catch (e) {
+      viteDevServer.ssrFixStacktrace(e)
+      next(e)
+    }
+  })
+
+  return new Promise((resolve, reject) => {
+    try {
+      httpServer.listen(port, () => {
+        resolve({
+          async close() {
+            await viteDevServer.close()
+          },
+          viteDevServer,
+          port,
+        })
+      })
+    } catch (e) {
+      reject(e)
+    }
+  })
+}
+
+if (!process.env.VITEST) {
+  serve().then(() => {
+    console.log(`http://localhost:${port}`)
+  })
+}

--- a/playground/config-overlay-ssr/vite.config.js
+++ b/playground/config-overlay-ssr/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+import checker from 'vite-plugin-checker'
+
+export default defineConfig({
+  plugins: [
+    checker({
+      typescript: true,
+      overlay: true,
+    }),
+  ],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -353,6 +353,21 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-checker
 
+  playground/config-overlay-ssr:
+    devDependencies:
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.9
+        version: 8.0.9(@types/node@20.19.9)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
+      vite-plugin-checker:
+        specifier: workspace:*
+        version: link:../../packages/vite-plugin-checker
+
   playground/config-terminal-false:
     devDependencies:
       eslint:


### PR DESCRIPTION
`transformIndexHtml` (the only overlay injection point) bailed on the `initialized` flag, which SSR frameworks like TanStack Start set by resolving the config more than once with a shared plugin instance — so errors showed in the terminal but never in the browser overlay. The flag only guards worker spawning, so drop it from `transformIndexHtml`. Adds a `config-overlay-ssr` repro playground.

Closes #733

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>