### PR TITLE
test: poll diagnostics emits instead of fixed timeout

### DIFF
--- a/playground/biome-default/__tests__/test.spec.ts
+++ b/playground/biome-default/__tests__/test.spec.ts
@@ -8,9 +8,9 @@ import {
   isServe,
   resetDiagnostics,
   resetReceivedLog,
-  sleepForEdit,
   sleepForServerReady,
   stripedLog,
+  waitForDiagnostics,
 } from '../../testUtils'
 
 describe('biome', () => {
@@ -26,7 +26,7 @@ describe('biome', () => {
       editFile('src/index.js', (code) =>
         code.replace(`var b = 'world'`, `const b = 'world'`),
       )
-      await sleepForEdit()
+      await waitForDiagnostics()
       expect(stringify(diagnostics)).toMatchSnapshot()
       expect(stripedLog).toMatchSnapshot()
     })

--- a/playground/config-initialIsOpen-error/__tests__/test.spec.ts
+++ b/playground/config-initialIsOpen-error/__tests__/test.spec.ts
@@ -6,9 +6,9 @@ import {
   getHmrOverlayText,
   isServe,
   pollingUntil,
-  sleep,
   sleepForEdit,
   sleepForServerReady,
+  waitForNoOverlay,
 } from '../../testUtils'
 
 describe('config-initialIsOpen-error', () => {
@@ -29,10 +29,7 @@ describe('config-initialIsOpen-error', () => {
 
       console.log('-- overlay dismiss after fix warning --')
       editFile('src/main.ts', (code) => code.replace('! as', ` as`))
-      await sleep(6000)
-      await expect(getHmrOverlayText()).rejects.toThrow(
-        'Invariant failed: .message-body is expected in shadow root'
-      )
+      await waitForNoOverlay()
     })
   })
 })

--- a/playground/config-overlay-changes/__tests__/test.spec.ts
+++ b/playground/config-overlay-changes/__tests__/test.spec.ts
@@ -6,9 +6,9 @@ import {
   getHmrOverlayText,
   isServe,
   pollingUntil,
-  sleep,
   sleepForEdit,
   sleepForServerReady,
+  waitForNoOverlay,
 } from '../../testUtils'
 
 describe('config-overlay-changes', () => {
@@ -30,10 +30,7 @@ describe('config-overlay-changes', () => {
       console.log('-- overlay dismiss after fix error --')
       editFile('src/main.ts', (code) => code.replace('var hello', `const hello`))
       editFile('src/main.ts', (code) => code.replace('! as', ` as`))
-      await sleep(6000)
-      await expect(getHmrOverlayText()).rejects.toThrow(
-        'Invariant failed: .message-body is expected in shadow root'
-      )
+      await waitForNoOverlay()
     })
   })
 })

--- a/playground/eslint-config-log-level/__tests__/test.spec.ts
+++ b/playground/eslint-config-log-level/__tests__/test.spec.ts
@@ -6,9 +6,9 @@ import {
   editFile,
   isServe,
   resetReceivedLog,
-  sleepForEdit,
   sleepForServerReady,
   stripedLog,
+  waitForDiagnostics,
 } from '../../testUtils'
 
 describe('eslint-config-log-level', () => {
@@ -21,7 +21,7 @@ describe('eslint-config-log-level', () => {
       console.log('-- edit error file --')
       resetReceivedLog()
       editFile('src/main.ts', (code) => code.replace(`'Hello'`, `'Hello~'`))
-      await sleepForEdit()
+      await waitForDiagnostics()
       expect(stringify(diagnostics)).toMatchSnapshot()
       expect(stripedLog).toMatchSnapshot()
     })

--- a/playground/eslint-default/__tests__/test.spec.ts
+++ b/playground/eslint-default/__tests__/test.spec.ts
@@ -8,9 +8,9 @@ import {
   isServe,
   log,
   resetReceivedLog,
-  sleepForEdit,
   sleepForServerReady,
   stripedLog,
+  waitForDiagnostics,
 } from '../../testUtils'
 
 describe('eslint-default', () => {
@@ -23,14 +23,14 @@ describe('eslint-default', () => {
       console.log('-- edit error file --')
       resetReceivedLog()
       editFile('src/main.ts', (code) => code.replace(`'Hello'`, `'Hello~'`))
-      await sleepForEdit()
+      await waitForDiagnostics()
       expect(stringify(diagnostics)).toMatchSnapshot()
       expect(stripedLog).toMatchSnapshot()
 
       console.log('-- edit non error file --')
       resetReceivedLog()
       editFile('src/text.ts', (code) => code.replace(`Vanilla`, `vanilla`))
-      await sleepForEdit()
+      await waitForDiagnostics()
       expect(stringify(diagnostics)).toMatchSnapshot()
       expect(stripedLog).toMatchSnapshot()
     })

--- a/playground/eslint-flat/__tests__/test.spec.ts
+++ b/playground/eslint-flat/__tests__/test.spec.ts
@@ -8,9 +8,9 @@ import {
   isServe,
   log,
   resetReceivedLog,
-  sleepForEdit,
   sleepForServerReady,
   stripedLog,
+  waitForDiagnostics,
 } from '../../testUtils'
 
 describe('eslint', () => {
@@ -23,7 +23,7 @@ describe('eslint', () => {
       console.log('-- edit error file --')
       resetReceivedLog()
       editFile('src/index.js', (code) => code.replace(`Hello`, `Hello~`))
-      await sleepForEdit()
+      await waitForDiagnostics()
       expect(stringify(diagnostics)).toMatchSnapshot()
       expect(stripedLog).toMatchSnapshot()
     })

--- a/playground/multiple-hmr/__tests__/test.spec.ts
+++ b/playground/multiple-hmr/__tests__/test.spec.ts
@@ -29,7 +29,7 @@ describe('multiple-hmr', () => {
       editFile('src/value.ts', (code) =>
         code.replace('export var value: string = 1', 'export var value: string = 2')
       )
-      await waitForDiagnostics({ checkers: 2 })
+      await waitForDiagnostics()
       expect(stringify(stable(diagnostics))).toMatchSnapshot()
       // don't know why striped log in disorder on Linux, while correct on mac and Windows
       // comment out for now to pass test cases stably and striped log is duplicated with diagnostics somehow.
@@ -42,14 +42,14 @@ describe('multiple-hmr', () => {
       editFile('src/value.ts', (code) =>
         code.replace('export var value: string = 2', `export var value = 2`)
       )
-      await waitForDiagnostics({ checkers: 2 })
+      await waitForDiagnostics()
       expect(stringify(stable(diagnostics))).toMatchSnapshot()
 
       console.log('-- fix eslint error --')
       resetDiagnostics()
       resetReceivedLog()
       editFile('src/value.ts', (code) => code.replace('var', 'const'))
-      await waitForDiagnostics({ checkers: 2 })
+      await waitForDiagnostics()
       expect(stringify(stable(diagnostics))).toMatchSnapshot()
     })
   })

--- a/playground/multiple-hmr/__tests__/test.spec.ts
+++ b/playground/multiple-hmr/__tests__/test.spec.ts
@@ -29,7 +29,7 @@ describe('multiple-hmr', () => {
       editFile('src/value.ts', (code) =>
         code.replace('export var value: string = 1', 'export var value: string = 2')
       )
-      await waitForDiagnostics()
+      await waitForDiagnostics({ checkers: 2 })
       expect(stringify(stable(diagnostics))).toMatchSnapshot()
       // don't know why striped log in disorder on Linux, while correct on mac and Windows
       // comment out for now to pass test cases stably and striped log is duplicated with diagnostics somehow.
@@ -42,14 +42,14 @@ describe('multiple-hmr', () => {
       editFile('src/value.ts', (code) =>
         code.replace('export var value: string = 2', `export var value = 2`)
       )
-      await waitForDiagnostics()
+      await waitForDiagnostics({ checkers: 2 })
       expect(stringify(stable(diagnostics))).toMatchSnapshot()
 
       console.log('-- fix eslint error --')
       resetDiagnostics()
       resetReceivedLog()
       editFile('src/value.ts', (code) => code.replace('var', 'const'))
-      await waitForDiagnostics()
+      await waitForDiagnostics({ checkers: 2 })
       expect(stringify(stable(diagnostics))).toMatchSnapshot()
     })
   })

--- a/playground/multiple-hmr/__tests__/test.spec.ts
+++ b/playground/multiple-hmr/__tests__/test.spec.ts
@@ -11,9 +11,9 @@ import {
   resetDiagnostics,
   resetReceivedLog,
   log,
-  sleepForEdit,
   sleepForServerReady,
   stripedLog,
+  waitForDiagnostics,
 } from '../../testUtils'
 
 describe('multiple-hmr', () => {
@@ -29,7 +29,7 @@ describe('multiple-hmr', () => {
       editFile('src/value.ts', (code) =>
         code.replace('export var value: string = 1', 'export var value: string = 2')
       )
-      await sleepForEdit()
+      await waitForDiagnostics()
       expect(stringify(stable(diagnostics))).toMatchSnapshot()
       // don't know why striped log in disorder on Linux, while correct on mac and Windows
       // comment out for now to pass test cases stably and striped log is duplicated with diagnostics somehow.
@@ -42,14 +42,14 @@ describe('multiple-hmr', () => {
       editFile('src/value.ts', (code) =>
         code.replace('export var value: string = 2', `export var value = 2`)
       )
-      await sleepForEdit()
+      await waitForDiagnostics()
       expect(stringify(stable(diagnostics))).toMatchSnapshot()
 
       console.log('-- fix eslint error --')
       resetDiagnostics()
       resetReceivedLog()
       editFile('src/value.ts', (code) => code.replace('var', 'const'))
-      await sleepForEdit()
+      await waitForDiagnostics()
       expect(stringify(stable(diagnostics))).toMatchSnapshot()
     })
   })

--- a/playground/multiple-reload/__tests__/test.spec.ts
+++ b/playground/multiple-reload/__tests__/test.spec.ts
@@ -11,9 +11,9 @@ import {
   resetDiagnostics,
   resetReceivedLog,
   log,
-  sleepForEdit,
   sleepForServerReady,
   stripedLog,
+  waitForDiagnostics,
 } from '../../testUtils'
 
 describe('multiple-reload', () => {
@@ -29,7 +29,7 @@ describe('multiple-reload', () => {
       editFile('src/main.ts', (code) =>
         code.replace(`var count: number = 0`, `var count: number = 1`)
       )
-      await sleepForEdit()
+      await waitForDiagnostics()
       expect(stringify(stable(diagnostics))).toMatchSnapshot()
       // don't know why striped log in disorder on Linux, while correct on mac and Windows
       // comment out for now to pass test cases stably and striped log is duplicated with diagnostics somehow.
@@ -42,14 +42,14 @@ describe('multiple-reload', () => {
       editFile('src/main.ts', (code) =>
         code.replace('var count: number = 1', `var count: string = 1`)
       )
-      await sleepForEdit()
+      await waitForDiagnostics()
       expect(stringify(stable(diagnostics))).toMatchSnapshot()
 
       console.log('-- fix eslint error --')
       resetDiagnostics()
       resetReceivedLog()
       editFile('src/main.ts', (code) => code.replace('var count: string = 1', 'const count = 0'))
-      await sleepForEdit()
+      await waitForDiagnostics()
       expect(stringify(stable(diagnostics))).toMatchSnapshot()
     })
   })

--- a/playground/multiple-reload/__tests__/test.spec.ts
+++ b/playground/multiple-reload/__tests__/test.spec.ts
@@ -29,7 +29,7 @@ describe('multiple-reload', () => {
       editFile('src/main.ts', (code) =>
         code.replace(`var count: number = 0`, `var count: number = 1`)
       )
-      await waitForDiagnostics()
+      await waitForDiagnostics({ checkers: 2 })
       expect(stringify(stable(diagnostics))).toMatchSnapshot()
       // don't know why striped log in disorder on Linux, while correct on mac and Windows
       // comment out for now to pass test cases stably and striped log is duplicated with diagnostics somehow.
@@ -42,14 +42,14 @@ describe('multiple-reload', () => {
       editFile('src/main.ts', (code) =>
         code.replace('var count: number = 1', `var count: string = 1`)
       )
-      await waitForDiagnostics()
+      await waitForDiagnostics({ checkers: 2 })
       expect(stringify(stable(diagnostics))).toMatchSnapshot()
 
       console.log('-- fix eslint error --')
       resetDiagnostics()
       resetReceivedLog()
       editFile('src/main.ts', (code) => code.replace('var count: string = 1', 'const count = 0'))
-      await waitForDiagnostics()
+      await waitForDiagnostics({ checkers: 2 })
       expect(stringify(stable(diagnostics))).toMatchSnapshot()
     })
   })

--- a/playground/multiple-reload/__tests__/test.spec.ts
+++ b/playground/multiple-reload/__tests__/test.spec.ts
@@ -29,7 +29,7 @@ describe('multiple-reload', () => {
       editFile('src/main.ts', (code) =>
         code.replace(`var count: number = 0`, `var count: number = 1`)
       )
-      await waitForDiagnostics({ checkers: 2 })
+      await waitForDiagnostics()
       expect(stringify(stable(diagnostics))).toMatchSnapshot()
       // don't know why striped log in disorder on Linux, while correct on mac and Windows
       // comment out for now to pass test cases stably and striped log is duplicated with diagnostics somehow.
@@ -42,14 +42,14 @@ describe('multiple-reload', () => {
       editFile('src/main.ts', (code) =>
         code.replace('var count: number = 1', `var count: string = 1`)
       )
-      await waitForDiagnostics({ checkers: 2 })
+      await waitForDiagnostics()
       expect(stringify(stable(diagnostics))).toMatchSnapshot()
 
       console.log('-- fix eslint error --')
       resetDiagnostics()
       resetReceivedLog()
       editFile('src/main.ts', (code) => code.replace('var count: string = 1', 'const count = 0'))
-      await waitForDiagnostics({ checkers: 2 })
+      await waitForDiagnostics()
       expect(stringify(stable(diagnostics))).toMatchSnapshot()
     })
   })

--- a/playground/oxlint-default/__tests__/test.spec.ts
+++ b/playground/oxlint-default/__tests__/test.spec.ts
@@ -9,9 +9,9 @@ import {
   log,
   resetDiagnostics,
   resetReceivedLog,
-  sleepForEdit,
   sleepForServerReady,
   stripedLog,
+  waitForDiagnostics,
 } from '../../testUtils'
 
 describe('oxlint-default', () => {
@@ -32,7 +32,7 @@ describe('oxlint-default', () => {
       editFile('src/main.ts', (code) =>
         code.replace('const unusedVariable1 = 42;', ''),
       )
-      await sleepForEdit()
+      await waitForDiagnostics()
 
       resetReceivedLog()
       resetDiagnostics()
@@ -53,7 +53,7 @@ describe('oxlint-default', () => {
       editFile('.oxlintrc.json', (code) =>
         code.replace('"correctness": "error"', '"correctness": "warn"'),
       )
-      await sleepForEdit()
+      await waitForDiagnostics()
 
       expect(stringify(diagnostics)).toMatchSnapshot()
       expect(stripedLog).toMatchSnapshot()

--- a/playground/stylelint-default/__tests__/test.spec.ts
+++ b/playground/stylelint-default/__tests__/test.spec.ts
@@ -8,9 +8,9 @@ import {
   isServe,
   log,
   resetReceivedLog,
-  sleepForEdit,
   sleepForServerReady,
   stripedLog,
+  waitForDiagnostics,
 } from '../../testUtils'
 
 describe('stylelint', () => {
@@ -23,7 +23,7 @@ describe('stylelint', () => {
       console.log('-- edit error file --')
       resetReceivedLog()
       editFile('src/style.css', (code) => code.replace(`color: rgb(0, 0, 0);`, `color: #fff;`))
-      await sleepForEdit()
+      await waitForDiagnostics()
       expect(stringify(diagnostics)).toMatchSnapshot()
       expect(stripedLog).toMatchSnapshot()
     })

--- a/playground/testUtils.ts
+++ b/playground/testUtils.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import invariant from 'tiny-invariant'
 import { expect } from 'vitest'
 
-import { page, testDir } from './vitestSetup'
+import { getDiagnosticsEmitCount, page, testDir } from './vitestSetup'
 
 import type { ElementHandle } from 'playwright-chromium'
 
@@ -106,4 +106,86 @@ export async function pollingUntil<T>(poll: () => Promise<T>, until: (actual: T)
       }
     }
   }
+}
+
+export interface WaitForDiagnosticsOptions {
+  /** Stop waiting after this many ms even if no new emit was observed. Default 30s on CI, 10s locally. */
+  timeout?: number
+  /** Once at least one new emit has been observed, wait this long without another emit before resolving. Default 500ms. */
+  quietMs?: number
+  /** Require this many emits beyond the count at call time. Default 1. */
+  minNewEmits?: number
+}
+
+/**
+ * Wait for the diagnostics ws stream to settle after an `editFile` call.
+ *
+ * Replaces the `await sleepForEdit()` pattern that was racing against slow
+ * lint round-trips on CI. We poll the emit counter exposed by
+ * `vitestSetup.ts` instead of sleeping for a fixed time, so the wait scales
+ * with how long the checker actually takes.
+ *
+ * The baseline is captured at call time, so tests do not have to
+ * `resetDiagnostics()` before `editFile()`; we just need at least
+ * `minNewEmits` new emits relative to the baseline, followed by `quietMs` of
+ * silence.
+ */
+export async function waitForDiagnostics(options: WaitForDiagnosticsOptions = {}): Promise<void> {
+  const { timeout = process.env.CI ? 30_000 : 10_000, quietMs = 500, minNewEmits = 1 } = options
+
+  const baseline = getDiagnosticsEmitCount()
+  const start = Date.now()
+  let lastEmitCount = baseline
+  let lastChangeAt = Date.now()
+
+  while (Date.now() - start < timeout) {
+    await sleep(50)
+    const current = getDiagnosticsEmitCount()
+    if (current !== lastEmitCount) {
+      lastEmitCount = current
+      lastChangeAt = Date.now()
+      continue
+    }
+    if (current - baseline >= minNewEmits && Date.now() - lastChangeAt >= quietMs) {
+      return
+    }
+  }
+
+  console.log(
+    `waitForDiagnostics timed out after ${timeout}ms with ${getDiagnosticsEmitCount() - baseline} new emit(s)`
+  )
+}
+
+export interface WaitForNoOverlayOptions {
+  /** Stop waiting after this many ms even if the overlay is still present. Default 20s on CI, 8s locally. */
+  timeout?: number
+  /** Once the overlay disappears, require it to stay gone this long before resolving. Default 500ms. */
+  quietMs?: number
+}
+
+/**
+ * Wait until `<vite-plugin-checker-error-overlay>` is absent and stays absent
+ * for `quietMs`. Replaces the `await sleep(6000)` + `rejects.toThrow(...)`
+ * pattern, which was racing two back-to-back edits whose lint cycles hadn't
+ * both completed within the fixed sleep.
+ */
+export async function waitForNoOverlay(options: WaitForNoOverlayOptions = {}): Promise<void> {
+  const { timeout = process.env.CI ? 20_000 : 8_000, quietMs = 500 } = options
+
+  const start = Date.now()
+  let goneSince: number | null = null
+
+  while (Date.now() - start < timeout) {
+    const dom = await page.$('vite-plugin-checker-error-overlay')
+    if (dom) {
+      goneSince = null
+    } else if (goneSince === null) {
+      goneSince = Date.now()
+    } else if (Date.now() - goneSince >= quietMs) {
+      return
+    }
+    await sleep(50)
+  }
+
+  throw new Error(`waitForNoOverlay timed out after ${timeout}ms; overlay still present`)
 }

--- a/playground/testUtils.ts
+++ b/playground/testUtils.ts
@@ -109,21 +109,15 @@ export async function pollingUntil<T>(poll: () => Promise<T>, until: (actual: T)
 }
 
 export interface WaitForDiagnosticsOptions {
-  /**
-   * Number of independent checkers the playground configures (e.g. `typescript: true` + ESLint = 2).
-   * The wait resolves once that many new emits have been observed since the call.
-   * Each checker emits exactly once per file change (see `dispatchDiagnostics` in
-   * the ESLint/TypeScript checker sources), including when its result set is empty.
-   * Default 1.
-   */
-  checkers?: number
-  /** Stop waiting after this many ms even if the expected emits haven't arrived. Default 30s on CI, 10s locally. */
+  /** Stop waiting after this many ms even if no new emit was observed. Default 30s on CI, 10s locally. */
   timeout?: number
   /**
-   * After the expected emits have arrived, wait this long without another
-   * emit before resolving. Guards against a checker emitting twice in quick
-   * succession (the second emit would change the diagnostics array under us).
-   * Default 500ms.
+   * After the most recent emit (or the call, if there have been no emits
+   * yet), wait this long without another emit before resolving. Default 2s.
+   *
+   * Sized to absorb the gap between two checkers reporting after the same
+   * edit (e.g. ESLint quickly, TypeScript a moment later in `multiple-hmr`)
+   * on slow CI runners.
    */
   quietMs?: number
 }
@@ -136,16 +130,16 @@ export interface WaitForDiagnosticsOptions {
  * `vitestSetup.ts` instead of sleeping for a fixed time, so the wait scales
  * with how long the checker actually takes.
  *
- * The baseline is captured at call time, so tests do not have to
- * `resetDiagnostics()` before `editFile()`; we just need `checkers` new emits
- * relative to the baseline, followed by `quietMs` of silence.
+ * The baseline is captured at call time, so tests do not need to
+ * `resetDiagnostics()` before `editFile()`; we resolve once `quietMs` have
+ * passed without another emit since the call (or since the most recent emit
+ * after the call, whichever is later).
  */
 export async function waitForDiagnostics(options: WaitForDiagnosticsOptions = {}): Promise<void> {
-  const { timeout = process.env.CI ? 30_000 : 10_000, quietMs = 500, checkers = 1 } = options
+  const { timeout = process.env.CI ? 30_000 : 10_000, quietMs = 2_000 } = options
 
-  const baseline = getDiagnosticsEmitCount()
   const start = Date.now()
-  let lastEmitCount = baseline
+  let lastEmitCount = getDiagnosticsEmitCount()
   let lastChangeAt = Date.now()
 
   while (Date.now() - start < timeout) {
@@ -156,14 +150,12 @@ export async function waitForDiagnostics(options: WaitForDiagnosticsOptions = {}
       lastChangeAt = Date.now()
       continue
     }
-    if (current - baseline >= checkers && Date.now() - lastChangeAt >= quietMs) {
+    if (Date.now() - lastChangeAt >= quietMs) {
       return
     }
   }
 
-  console.log(
-    `waitForDiagnostics timed out after ${timeout}ms; expected ${checkers} new emit(s), got ${getDiagnosticsEmitCount() - baseline}`
-  )
+  console.log(`waitForDiagnostics timed out after ${timeout}ms`)
 }
 
 export interface WaitForNoOverlayOptions {
@@ -191,8 +183,16 @@ export async function waitForNoOverlay(options: WaitForNoOverlayOptions = {}): P
   let goneSince: number | null = null
 
   while (Date.now() - start < timeout) {
-    const dom = await page.$('vite-plugin-checker-error-overlay')
-    const messageBody = dom ? await dom.$('.message-body') : null
+    let messageBody: Awaited<ReturnType<(typeof page)['$']>> = null
+    try {
+      const dom = await page.$('vite-plugin-checker-error-overlay')
+      messageBody = dom ? await dom.$('.message-body') : null
+    } catch {
+      // Page is mid-reload (vite triggers a full reload after each edit in
+      // playgrounds without HMR). Playwright throws
+      // "Unable to adopt element handle from a different document" on the
+      // navigation boundary; treat as transient and re-poll.
+    }
     if (messageBody) {
       goneSince = null
     } else if (goneSince === null) {

--- a/playground/testUtils.ts
+++ b/playground/testUtils.ts
@@ -109,12 +109,23 @@ export async function pollingUntil<T>(poll: () => Promise<T>, until: (actual: T)
 }
 
 export interface WaitForDiagnosticsOptions {
-  /** Stop waiting after this many ms even if no new emit was observed. Default 30s on CI, 10s locally. */
+  /**
+   * Number of independent checkers the playground configures (e.g. `typescript: true` + ESLint = 2).
+   * The wait resolves once that many new emits have been observed since the call.
+   * Each checker emits exactly once per file change (see `dispatchDiagnostics` in
+   * the ESLint/TypeScript checker sources), including when its result set is empty.
+   * Default 1.
+   */
+  checkers?: number
+  /** Stop waiting after this many ms even if the expected emits haven't arrived. Default 30s on CI, 10s locally. */
   timeout?: number
-  /** Once at least one new emit has been observed, wait this long without another emit before resolving. Default 500ms. */
+  /**
+   * After the expected emits have arrived, wait this long without another
+   * emit before resolving. Guards against a checker emitting twice in quick
+   * succession (the second emit would change the diagnostics array under us).
+   * Default 500ms.
+   */
   quietMs?: number
-  /** Require this many emits beyond the count at call time. Default 1. */
-  minNewEmits?: number
 }
 
 /**
@@ -126,12 +137,11 @@ export interface WaitForDiagnosticsOptions {
  * with how long the checker actually takes.
  *
  * The baseline is captured at call time, so tests do not have to
- * `resetDiagnostics()` before `editFile()`; we just need at least
- * `minNewEmits` new emits relative to the baseline, followed by `quietMs` of
- * silence.
+ * `resetDiagnostics()` before `editFile()`; we just need `checkers` new emits
+ * relative to the baseline, followed by `quietMs` of silence.
  */
 export async function waitForDiagnostics(options: WaitForDiagnosticsOptions = {}): Promise<void> {
-  const { timeout = process.env.CI ? 30_000 : 10_000, quietMs = 500, minNewEmits = 1 } = options
+  const { timeout = process.env.CI ? 30_000 : 10_000, quietMs = 500, checkers = 1 } = options
 
   const baseline = getDiagnosticsEmitCount()
   const start = Date.now()
@@ -146,28 +156,33 @@ export async function waitForDiagnostics(options: WaitForDiagnosticsOptions = {}
       lastChangeAt = Date.now()
       continue
     }
-    if (current - baseline >= minNewEmits && Date.now() - lastChangeAt >= quietMs) {
+    if (current - baseline >= checkers && Date.now() - lastChangeAt >= quietMs) {
       return
     }
   }
 
   console.log(
-    `waitForDiagnostics timed out after ${timeout}ms with ${getDiagnosticsEmitCount() - baseline} new emit(s)`
+    `waitForDiagnostics timed out after ${timeout}ms; expected ${checkers} new emit(s), got ${getDiagnosticsEmitCount() - baseline}`
   )
 }
 
 export interface WaitForNoOverlayOptions {
-  /** Stop waiting after this many ms even if the overlay is still present. Default 20s on CI, 8s locally. */
+  /** Stop waiting after this many ms even if the overlay still shows a message. Default 20s on CI, 8s locally. */
   timeout?: number
-  /** Once the overlay disappears, require it to stay gone this long before resolving. Default 500ms. */
+  /** Once the overlay clears, require it to stay clear this long before resolving. Default 500ms. */
   quietMs?: number
 }
 
 /**
- * Wait until `<vite-plugin-checker-error-overlay>` is absent and stays absent
- * for `quietMs`. Replaces the `await sleep(6000)` + `rejects.toThrow(...)`
- * pattern, which was racing two back-to-back edits whose lint cycles hadn't
- * both completed within the fixed sleep.
+ * Wait until `<vite-plugin-checker-error-overlay>` reports no diagnostics and
+ * stays empty for `quietMs`. Replaces the `await sleep(6000)` +
+ * `rejects.toThrow(...)` pattern, which was racing two back-to-back edits
+ * whose lint cycles hadn't both completed within the fixed sleep.
+ *
+ * The overlay custom element stays in the DOM for the lifetime of the page
+ * (see `packages/runtime/src/main.ts`); when there are no diagnostics, its
+ * inner `<template v-if="shouldRender">` is not rendered, so we detect a
+ * dismissed overlay by the absence of `.message-body` inside its shadow root.
  */
 export async function waitForNoOverlay(options: WaitForNoOverlayOptions = {}): Promise<void> {
   const { timeout = process.env.CI ? 20_000 : 8_000, quietMs = 500 } = options
@@ -177,7 +192,8 @@ export async function waitForNoOverlay(options: WaitForNoOverlayOptions = {}): P
 
   while (Date.now() - start < timeout) {
     const dom = await page.$('vite-plugin-checker-error-overlay')
-    if (dom) {
+    const messageBody = dom ? await dom.$('.message-body') : null
+    if (messageBody) {
       goneSince = null
     } else if (goneSince === null) {
       goneSince = Date.now()
@@ -187,5 +203,7 @@ export async function waitForNoOverlay(options: WaitForNoOverlayOptions = {}): P
     await sleep(50)
   }
 
-  throw new Error(`waitForNoOverlay timed out after ${timeout}ms; overlay still present`)
+  throw new Error(
+    `waitForNoOverlay timed out after ${timeout}ms; overlay still reporting diagnostics`
+  )
 }

--- a/playground/typescript-react/__tests__/test.spec.ts
+++ b/playground/typescript-react/__tests__/test.spec.ts
@@ -9,9 +9,9 @@ import {
   isServe,
   log,
   resetReceivedLog,
-  sleepForEdit,
   sleepForServerReady,
   stripedLog,
+  waitForDiagnostics,
 } from '../../testUtils'
 
 describe('typescript-react', () => {
@@ -24,7 +24,7 @@ describe('typescript-react', () => {
       console.log('-- edit file --')
       resetReceivedLog()
       editFile('src/App.tsx', (code) => code.replace('useState<string>(1)', 'useState<string>(2)'))
-      await sleepForEdit()
+      await waitForDiagnostics()
       expect(stringify(diagnostics)).toMatchSnapshot()
       expect(stripedLog).toMatchSnapshot()
     })

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -58,6 +58,18 @@ export let stripedLog: string[] = []
 export let diagnostics: string[] = []
 export let buildSucceed: boolean
 
+let diagnosticsEmitCount = 0
+
+/**
+ * Number of `vite-plugin-checker:error` ws messages received from the dev
+ * server since the last `resetDiagnostics()`. Empty-diagnostics emissions
+ * still count: tests use this to know a checker has finished a re-lint cycle,
+ * even when the final result is `[]`.
+ */
+export function getDiagnosticsEmitCount(): number {
+  return diagnosticsEmitCount
+}
+
 export let resolvedConfig: ResolvedConfig = undefined!
 
 export let page: Page = undefined!
@@ -210,6 +222,7 @@ export async function startDefaultServe({
         }
 
         diagnostics = diagnostics.concat(payload.data.diagnostics)
+        diagnosticsEmitCount++
       }
 
       // @ts-ignore
@@ -259,4 +272,5 @@ export function resetReceivedLog() {
 
 export function resetDiagnostics() {
   diagnostics = []
+  diagnosticsEmitCount = 0
 }

--- a/playground/vue-tsc-buildmode/__tests__/test.spec.ts
+++ b/playground/vue-tsc-buildmode/__tests__/test.spec.ts
@@ -9,9 +9,9 @@ import {
   isServe,
   log,
   resetReceivedLog,
-  sleepForEdit,
   sleepForServerReady,
   stripedLog,
+  waitForDiagnostics,
 } from '../../testUtils'
 
 describe('vue-tsc-build-mode', () => {
@@ -26,7 +26,7 @@ describe('vue-tsc-build-mode', () => {
       editFile('packages/utils/src/helpers.ts', (code) =>
         code.replace('processData(input: number)', 'processData(input: boolean)')
       )
-      await sleepForEdit(2)
+      await waitForDiagnostics()
       expect(stringify(diagnostics)).toMatchSnapshot()
       expect(stripedLog).toMatchSnapshot()
     })

--- a/playground/vue-tsc-vue3/__tests__/test.spec.ts
+++ b/playground/vue-tsc-vue3/__tests__/test.spec.ts
@@ -9,9 +9,9 @@ import {
   isServe,
   log,
   resetReceivedLog,
-  sleepForEdit,
   sleepForServerReady,
   stripedLog,
+  waitForDiagnostics,
 } from '../../testUtils'
 
 describe('vue-tsc-vue3', () => {
@@ -26,7 +26,7 @@ describe('vue-tsc-vue3', () => {
       editFile('src/App.vue', (code) =>
         code.replace('<HelloWorld msg1="Diana" />', '<HelloWorld msg2="Diana" />')
       )
-      await sleepForEdit(2)
+      await waitForDiagnostics()
       expect(stringify(diagnostics)).toMatchSnapshot()
       expect(stripedLog).toMatchSnapshot()
     })


### PR DESCRIPTION
this aims to reduce flakiness by moving to polling instead of a fixed timeout (which can sometimes result in no diagnostics being caught)