### PR TITLE
fix(checker): don't crash when a watched file is removed mid-lint

### DIFF
--- a/packages/vite-plugin-checker/__tests__/utils.spec.ts
+++ b/packages/vite-plugin-checker/__tests__/utils.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { ignoreTransientFsError, isTransientFsError } from '../src/utils'
+
+const fsError = (code: string) => Object.assign(new Error(code), { code })
+
+describe('isTransientFsError', () => {
+  it.each(['ENOENT', 'EBUSY', 'EPERM', 'EACCES'])(
+    'treats %s as transient',
+    (code) => {
+      expect(isTransientFsError(fsError(code))).toBe(true)
+    },
+  )
+
+  it('does not treat unrelated error codes as transient', () => {
+    expect(isTransientFsError(fsError('EISDIR'))).toBe(false)
+  })
+
+  it('returns false for errors without a code and non-error values', () => {
+    expect(isTransientFsError(new Error('boom'))).toBe(false)
+    expect(isTransientFsError('ENOENT')).toBe(false)
+    expect(isTransientFsError(null)).toBe(false)
+    expect(isTransientFsError(undefined)).toBe(false)
+  })
+})
+
+describe('ignoreTransientFsError', () => {
+  it('swallows transient FS errors', () => {
+    expect(() => ignoreTransientFsError(fsError('ENOENT'))).not.toThrow()
+  })
+
+  it('rethrows anything else so genuine failures still surface', () => {
+    const error = fsError('EISDIR')
+    expect(() => ignoreTransientFsError(error)).toThrow(error)
+  })
+})

--- a/packages/vite-plugin-checker/src/checkers/biome/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/biome/main.ts
@@ -135,13 +135,11 @@ const createDiagnostic: CreateDiagnostic<'biome'> = (pluginConfig) => {
         cwd: root,
         ignored: (path: string) => path.includes('node_modules'),
       })
-      // `handleFileChange` reads the changed file, which may be removed or
-      // mid-replace by the time it runs (e.g. atomic editor saves). Ignore the
-      // resulting transient FS errors so a single racing event can't crash the
-      // dev server — the next stable write fires a fresh event.
+
       watcher.on('change', (filePath) => {
         handleFileChange(filePath, 'change').catch(ignoreTransientFsError)
       })
+
       watcher.on('unlink', (filePath) => {
         handleFileChange(filePath, 'unlink').catch(ignoreTransientFsError)
       })

--- a/packages/vite-plugin-checker/src/checkers/biome/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/biome/main.ts
@@ -18,6 +18,7 @@ import {
   type CreateDiagnostic,
   DiagnosticLevel,
 } from '../../types.js'
+import { ignoreTransientFsError } from '../../utils.js'
 import { getBiomeCommand, runBiome, severityMap } from './cli.js'
 
 const __filename = fileURLToPath(import.meta.url)
@@ -134,11 +135,15 @@ const createDiagnostic: CreateDiagnostic<'biome'> = (pluginConfig) => {
         cwd: root,
         ignored: (path: string) => path.includes('node_modules'),
       })
-      watcher.on('change', async (filePath) => {
-        handleFileChange(filePath, 'change')
+      // `handleFileChange` reads the changed file, which may be removed or
+      // mid-replace by the time it runs (e.g. atomic editor saves). Ignore the
+      // resulting transient FS errors so a single racing event can't crash the
+      // dev server — the next stable write fires a fresh event.
+      watcher.on('change', (filePath) => {
+        handleFileChange(filePath, 'change').catch(ignoreTransientFsError)
       })
-      watcher.on('unlink', async (filePath) => {
-        handleFileChange(filePath, 'unlink')
+      watcher.on('unlink', (filePath) => {
+        handleFileChange(filePath, 'unlink').catch(ignoreTransientFsError)
       })
     },
   }

--- a/packages/vite-plugin-checker/src/checkers/eslint/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/eslint/main.ts
@@ -228,13 +228,10 @@ const createDiagnostic: CreateDiagnostic<'eslint'> = (pluginConfig) => {
         ignored: createIgnore(root, files),
       })
 
-      // `handleFileChange` reads the changed file, which may be removed or
-      // mid-replace by the time it runs (e.g. atomic editor saves). Ignore the
-      // resulting transient FS errors so a single racing event can't crash the
-      // dev server — the next stable write fires a fresh event.
       watcher.on('change', (filePath) => {
         handleFileChange(filePath, 'change').catch(ignoreTransientFsError)
       })
+
       watcher.on('unlink', (filePath) => {
         handleFileChange(filePath, 'unlink').catch(ignoreTransientFsError)
       })

--- a/packages/vite-plugin-checker/src/checkers/eslint/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/eslint/main.ts
@@ -20,6 +20,7 @@ import {
   toClientPayload,
 } from '../../logger.js'
 import { ACTION_TYPES, DiagnosticLevel } from '../../types.js'
+import { ignoreTransientFsError } from '../../utils.js'
 import { translateOptions } from './cli.js'
 import { options as optionator } from './options.js'
 
@@ -227,11 +228,15 @@ const createDiagnostic: CreateDiagnostic<'eslint'> = (pluginConfig) => {
         ignored: createIgnore(root, files),
       })
 
-      watcher.on('change', async (filePath) => {
-        handleFileChange(filePath, 'change')
+      // `handleFileChange` reads the changed file, which may be removed or
+      // mid-replace by the time it runs (e.g. atomic editor saves). Ignore the
+      // resulting transient FS errors so a single racing event can't crash the
+      // dev server — the next stable write fires a fresh event.
+      watcher.on('change', (filePath) => {
+        handleFileChange(filePath, 'change').catch(ignoreTransientFsError)
       })
-      watcher.on('unlink', async (filePath) => {
-        handleFileChange(filePath, 'unlink')
+      watcher.on('unlink', (filePath) => {
+        handleFileChange(filePath, 'unlink').catch(ignoreTransientFsError)
       })
     },
   }

--- a/packages/vite-plugin-checker/src/checkers/oxlint/server.ts
+++ b/packages/vite-plugin-checker/src/checkers/oxlint/server.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 import chokidar from 'chokidar'
 import type { FileDiagnosticManager } from '../../FileDiagnosticManager.js'
 import { filterLogLevel } from '../../logger.js'
+import { ignoreTransientFsError } from '../../utils.js'
 import { runOxlint } from './cli.js'
 import { dispatchDiagnostics } from './diagnostics.js'
 import type { ResolvedOptions } from './options.js'
@@ -25,12 +26,15 @@ export async function setupDevServer(
     ignored: (path: string) => path.includes('node_modules'),
   })
 
-  watcher.on('change', async (filePath) => {
-    await handleFileChange(root, options.command, filePath, manager)
-    dispatchDiagnostics(
-      filterLogLevel(manager.getDiagnostics(), options.logLevel),
-      displayTargets,
-    )
+  watcher.on('change', (filePath) => {
+    handleFileChange(root, options.command, filePath, manager)
+      .then(() => {
+        dispatchDiagnostics(
+          filterLogLevel(manager.getDiagnostics(), options.logLevel),
+          displayTargets,
+        )
+      })
+      .catch(ignoreTransientFsError)
   })
 
   watcher.on('unlink', (filePath) => {

--- a/packages/vite-plugin-checker/src/checkers/stylelint/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/stylelint/main.ts
@@ -17,6 +17,7 @@ import {
   toClientPayload,
 } from '../../logger.js'
 import { ACTION_TYPES, DiagnosticLevel } from '../../types.js'
+import { ignoreTransientFsError } from '../../utils.js'
 import { translateOptions } from './options.js'
 
 const manager = new FileDiagnosticManager()
@@ -142,11 +143,15 @@ const createDiagnostic: CreateDiagnostic<'stylelint'> = (pluginConfig) => {
         ignored: createIgnore(root, translatedOptions.files),
       })
 
-      watcher.on('change', async (filePath) => {
-        handleFileChange(filePath, 'change')
+      // `handleFileChange` reads the changed file, which may be removed or
+      // mid-replace by the time it runs (e.g. atomic editor saves). Ignore the
+      // resulting transient FS errors so a single racing event can't crash the
+      // dev server — the next stable write fires a fresh event.
+      watcher.on('change', (filePath) => {
+        handleFileChange(filePath, 'change').catch(ignoreTransientFsError)
       })
-      watcher.on('unlink', async (filePath) => {
-        handleFileChange(filePath, 'unlink')
+      watcher.on('unlink', (filePath) => {
+        handleFileChange(filePath, 'unlink').catch(ignoreTransientFsError)
       })
     },
   }

--- a/packages/vite-plugin-checker/src/checkers/stylelint/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/stylelint/main.ts
@@ -143,13 +143,10 @@ const createDiagnostic: CreateDiagnostic<'stylelint'> = (pluginConfig) => {
         ignored: createIgnore(root, translatedOptions.files),
       })
 
-      // `handleFileChange` reads the changed file, which may be removed or
-      // mid-replace by the time it runs (e.g. atomic editor saves). Ignore the
-      // resulting transient FS errors so a single racing event can't crash the
-      // dev server — the next stable write fires a fresh event.
       watcher.on('change', (filePath) => {
         handleFileChange(filePath, 'change').catch(ignoreTransientFsError)
       })
+
       watcher.on('unlink', (filePath) => {
         handleFileChange(filePath, 'unlink').catch(ignoreTransientFsError)
       })

--- a/packages/vite-plugin-checker/src/utils.ts
+++ b/packages/vite-plugin-checker/src/utils.ts
@@ -5,3 +5,26 @@ import { isMainThread as _isMainThread, threadId } from 'node:worker_threads'
 // @ts-expect-error use Vitest
 export const isInVitestEntryThread = threadId === 0 && process.env.VITEST
 export const isMainThread = _isMainThread || isInVitestEntryThread
+
+// Filesystem errors that are expected during watching: editors commonly save
+// via an atomic rename (write temp file, then replace), and branch switches or
+// deletions can remove a file between a watcher event firing and the checker
+// reading it. In that window the path briefly doesn't exist (or isn't readable
+// yet), so a `change`/`unlink` handler can hit one of these codes. They are
+// transient and should not crash the dev server — the next stable write fires a
+// fresh event. See #461 for the same race in the ignore-check path.
+const TRANSIENT_FS_ERROR_CODES = new Set(['ENOENT', 'EBUSY', 'EPERM', 'EACCES'])
+
+export function isTransientFsError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false
+  const { code } = error as NodeJS.ErrnoException
+  return code !== undefined && TRANSIENT_FS_ERROR_CODES.has(code)
+}
+
+// `.catch` handler for watcher-triggered checker work. Ignore the transient FS
+// errors that happen when a file is removed/replaced mid-read, and rethrow
+// anything else so genuine failures still surface instead of being hidden.
+export function ignoreTransientFsError(error: unknown): void {
+  if (isTransientFsError(error)) return
+  throw error
+}


### PR DESCRIPTION
> Note: the changes are AI generated, but I reviewed the pull request changes and it also fixes the problem on my system.

## Problem

In dev mode the ESLint, Stylelint and Biome checkers re-lint a file on every chokidar `change`/`unlink` event:

```ts
watcher.on('change', async (filePath) => {
  handleFileChange(filePath, 'change') // floating promise — never awaited or caught
})
```

`handleFileChange()` reads the changed file (e.g. `eslint.lintFiles(filePath)`). If the file is gone or mid-replace by the time the read runs, the read rejects with a transient FS error and — because the promise is floated — the rejection is unhandled and **crashes the whole Vite dev server**:

```
node:internal/event_target:1118
  process.nextTick(() => { throw err; });
                           ^
Error: ENOENT: no such file or directory, open '.../src/js/hero-startpage.ts'
    at async readAndVerifyFile (.../eslint/lib/eslint/eslint-helpers.js:1281:16) {
  errno: -2, code: 'ENOENT', syscall: 'open', path: '.../hero-startpage.ts'
}
```

This races against normal editor behaviour:

- **Atomic saves** (write temp file → `rename()` over the original) leave the path briefly nonexistent. Editors / formatters that save this way trigger it; rapid successive saves (e.g. AI-assisted editing, format-on-save) make it much more likely.
- **Branch switches / deletions** that remove a watched file between the event firing and the read.

It's intermittent because it only fires when the lint read lands inside that short window.

## Fix

Attach a `.catch()` to the watcher-triggered work that **ignores transient FS errors** (`ENOENT`, `EBUSY`, `EPERM`, `EACCES`) and **rethrows anything else**, so genuine failures still surface. The next stable write fires a fresh event and re-lints, so no diagnostics are lost.

This mirrors the existing guard added for the ignore-check path in #461 (`glob.ts`: *"do not ignore files that have been deleted as the watcher is iterating on them"*) — that fix covered `statSync` in the ignore matcher; this covers the `lintFiles`/read path, which is still unguarded.

Applied consistently to the three checkers that share this pattern: `eslint`, `stylelint`, `biome`.