### PR TITLE
fix(eslint): fix path resolution for changed files

### DIFF
--- a/packages/vite-plugin-checker/src/checkers/eslint/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/eslint/main.ts
@@ -186,14 +186,15 @@ const createDiagnostic: CreateDiagnostic<'eslint'> = (pluginConfig) => {
           if (hasExtensionsConfig && !extensions.includes(extension)) return
         }
 
-        const isChangedFileIgnored = await eslint.isPathIgnored(filePath)
+        const absPath = path.resolve(root, filePath)
+
+        const isChangedFileIgnored = await eslint.isPathIgnored(absPath)
         if (isChangedFileIgnored) return
 
-        const absPath = path.resolve(root, filePath)
         if (type === 'unlink') {
           manager.updateByFileId(absPath, [])
         } else if (type === 'change') {
-          const diagnosticsOfChangedFile = await eslint.lintFiles(filePath)
+          const diagnosticsOfChangedFile = await eslint.lintFiles(absPath)
           const newDiagnostics = diagnosticsOfChangedFile.flatMap((d) =>
             normalizeEslintDiagnostic(d),
           )

--- a/playground/eslint-cwd-override/__tests__/test.spec.ts
+++ b/playground/eslint-cwd-override/__tests__/test.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import {
+  diagnostics,
+  editFile,
+  isServe,
+  resetReceivedLog,
+  sleepForServerReady,
+  stripedLog,
+  waitForDiagnostics,
+} from '../../testUtils'
+
+describe('eslint-cwd-override', () => {
+  describe.runIf(isServe)('serve', () => {
+    it('lints changed files when eslint cwd differs from vite root', async () => {
+      await sleepForServerReady()
+      expect(diagnostics).toHaveLength(1)
+      expect(stripedLog.join('\n')).toContain('Missing semicolon')
+
+      resetReceivedLog()
+      editFile('src/index.js', (code) => `${code}const b = "world"\n`)
+      await waitForDiagnostics()
+      expect(diagnostics).toHaveLength(2)
+      expect(stripedLog.join('\n')).toContain('Missing semicolon')
+    })
+  })
+})

--- a/playground/eslint-cwd-override/eslint.config.js
+++ b/playground/eslint-cwd-override/eslint.config.js
@@ -1,0 +1,8 @@
+export default [
+  {
+    files: ['src/**/*.js'],
+    rules: {
+      semi: 'error',
+    },
+  },
+]

--- a/playground/eslint-cwd-override/index.html
+++ b/playground/eslint-cwd-override/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.js"></script>
+  </body>
+</html>

--- a/playground/eslint-cwd-override/package.json
+++ b/playground/eslint-cwd-override/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@playground/eslint-cwd-override",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite",
+    "lint": "eslint .",
+    "serve": "vite preview"
+  },
+  "devDependencies": {
+    "eslint": "^10.2.1",
+    "vite": "^8.0.9",
+    "vite-plugin-checker": "workspace:*"
+  }
+}

--- a/playground/eslint-cwd-override/src/index.js
+++ b/playground/eslint-cwd-override/src/index.js
@@ -1,0 +1,1 @@
+const a = "hello"

--- a/playground/eslint-cwd-override/vite.config.js
+++ b/playground/eslint-cwd-override/vite.config.js
@@ -1,0 +1,22 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+import checker from 'vite-plugin-checker'
+
+const dirname = path.dirname(fileURLToPath(import.meta.url))
+
+export default defineConfig({
+  plugins: [
+    checker({
+      enableBuild: false,
+      eslint: {
+        lintCommand: 'eslint "./**/*.js"',
+        dev: {
+          overrideConfig: {
+            cwd: path.resolve(dirname, 'src'),
+          },
+        },
+      },
+    }),
+  ],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -392,6 +392,18 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-checker
 
+  playground/eslint-cwd-override:
+    devDependencies:
+      eslint:
+        specifier: ^10.2.1
+        version: 10.5.0(jiti@2.7.0)
+      vite:
+        specifier: ^8.0.9
+        version: 8.0.16(@types/node@20.19.9)(jiti@2.7.0)(yaml@2.9.0)
+      vite-plugin-checker:
+        specifier: workspace:*
+        version: link:../../packages/vite-plugin-checker
+
   playground/eslint-default:
     devDependencies:
       eslint:


### PR DESCRIPTION
#631.

Changed files are currently linted using the Vite-root-relative `filePath`, while the initial lint pass uses the glob from `lintCommand`. When ESLint is configured with a different `cwd` than Vite's `root`, won't resolve correctly and ESLint fails with "No files matching..." errors.

This PR changes incremental linting to use the existing `absPath` for both `eslint.isPathIgnored()` and `eslint.lintFiles()`. This makes incremental linting consistent with the initial lint pass and ensures changed files can be linted correctly regardless of the relationship between `root` and `cwd`.