### PR TITLE
feat(typescript): add experimental support for TypeScript 7

### DIFF
--- a/packages/vite-plugin-checker/src/checkers/typescript/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/typescript/main.ts
@@ -70,6 +70,7 @@ const createDiagnostic: CreateDiagnostic<'typescript'> = (pluginConfig) => {
       if (isTsV7) {
         const { spawn } = await import('node:child_process')
         const { existsSync, readFileSync } = await import('node:fs')
+        const { createRequire } = await import('node:module')
         const { stripVTControlCharacters: strip } = await import('node:util')
 
         const tsconfigPath = path.resolve(
@@ -89,102 +90,154 @@ const createDiagnostic: CreateDiagnostic<'typescript'> = (pluginConfig) => {
           '--pretty',
           'false',
         ]
-        args.push('-p', tsconfigPath)
+        // In build mode the project path is a positional argument to `-b`;
+        // `tsc -b -p <path>` is rejected. Non-build mode uses `-p`.
+        if (isBuildMode) {
+          args.push(tsconfigPath)
+        } else {
+          args.push('-p', tsconfigPath)
+        }
 
-        const tscProcess = spawn('tsc', args, { cwd: finalConfig.root })
+        let tscBin = 'tsc'
+        let runWithNode = false
+        try {
+          const requireFromRoot = createRequire(
+            path.join(finalConfig.root, 'noop.js'),
+          )
+          const tsPkgJson = requireFromRoot.resolve(
+            `${finalConfig.typescriptPath}/package.json`,
+          )
+          tscBin = path.join(path.dirname(tsPkgJson), 'bin', 'tsc')
+          runWithNode = existsSync(tscBin)
+        } catch {}
+
+        const tscProcess = runWithNode
+          ? spawn(process.execPath, [tscBin, ...args], {
+              cwd: finalConfig.root,
+            })
+          : spawn(tscBin, args, { cwd: finalConfig.root, shell: true })
 
         let logChunk = ''
 
-        tscProcess.stdout.on('data', (chunk: Buffer) => {
-          const lines = chunk.toString().split('\n')
-          for (const rawLine of lines) {
-            // Strip \r and timestamp prefix that tsc --watch prepends to each line
-            const line = rawLine
-              .replace(/\r$/, '')
-              .replace(/^\d{1,2}:\d{2}:\d{2}\s+[AP]M\s+-\s+/, '')
+        // Buffer partial lines across `data` chunks; tsc may split a line
+        // (or a multi-line diagnostic) across chunk boundaries.
+        let stdoutBuffer = ''
+        // Accumulates continuation lines of a multi-line diagnostic message.
+        let pendingDiag: NormalizedDiagnostic | null = null
 
-            // Parse: "<file>(<line>,<col>): error TS<code>: <message>"
-            // This is the --pretty false format; the pretty format uses
-            // "<file>:<line>:<col> - error TS<code>: <message>" instead.
-            const diagMatch = line.match(
-              /^(.+?)\((\d+),(\d+)\): (error|warning) TS(\d+): (.+)$/,
-            )
-            if (diagMatch) {
-              const [, file, lineStr, colStr, severity, tsCode, message] =
-                diagMatch
-              const lineNum = +lineStr!
-              const colNum = +colStr!
+        const flushPendingDiag = () => {
+          if (!pendingDiag) return
+          currDiagnostics.push(diagnosticToRuntimeError(pendingDiag))
+          logChunk +=
+            os.EOL + diagnosticToTerminalLog(pendingDiag, 'TypeScript')
+          pendingDiag = null
+        }
 
-              // tsc outputs paths relative to its cwd (finalConfig.root);
-              // resolve to absolute so readFileSync works in the worker thread
-              const absFile = path.resolve(finalConfig.root, file!)
+        const handleLine = (rawLine: string) => {
+          // Strip \r and timestamp prefix that tsc --watch prepends to each line
+          const line = rawLine
+            .replace(/\r$/, '')
+            .replace(/^\d{1,2}:\d{2}:\d{2}\s+[AP]M\s+-\s+/, '')
 
-              let codeFrame: string | undefined
-              let stripedCodeFrame: string | undefined
-              if (existsSync(absFile)) {
-                try {
-                  const source = readFileSync(absFile, 'utf-8')
-                  codeFrame = createFrame(source, {
-                    start: { line: lineNum, column: colNum },
-                  })
-                  stripedCodeFrame = strip(codeFrame)
-                } catch {}
-              }
+          // Parse: "<file>(<line>,<col>): error TS<code>: <message>"
+          // This is the --pretty false format; the pretty format uses
+          // "<file>:<line>:<col> - error TS<code>: <message>" instead.
+          const diagMatch = line.match(
+            /^(.+?)\((\d+),(\d+)\): (error|warning) TS(\d+): (.+)$/,
+          )
+          if (diagMatch) {
+            flushPendingDiag()
+            const [, file, lineStr, colStr, severity, tsCode, message] =
+              diagMatch
+            const lineNum = +lineStr!
+            const colNum = +colStr!
 
-              const normalized: NormalizedDiagnostic = {
-                message: `TS${tsCode}: ${message}`,
-                conclusion: '',
-                id: absFile,
-                checker: 'TypeScript',
-                codeFrame,
-                stripedCodeFrame,
-                loc: {
+            // tsc outputs paths relative to its cwd (finalConfig.root);
+            // resolve to absolute so readFileSync works in the worker thread
+            const absFile = path.resolve(finalConfig.root, file!)
+
+            let codeFrame: string | undefined
+            let stripedCodeFrame: string | undefined
+            if (existsSync(absFile)) {
+              try {
+                const source = readFileSync(absFile, 'utf-8')
+                codeFrame = createFrame(source, {
                   start: { line: lineNum, column: colNum },
-                },
-                level:
-                  severity === 'warning'
-                    ? DiagnosticLevel.Warning
-                    : DiagnosticLevel.Error,
-              }
-              currDiagnostics.push(diagnosticToRuntimeError(normalized))
-              logChunk +=
-                os.EOL + diagnosticToTerminalLog(normalized, 'TypeScript')
+                })
+                stripedCodeFrame = strip(codeFrame)
+              } catch {}
             }
 
-            // Parse: "Found X errors." or "Found X errors. Watching for file changes."
-            const summaryMatch = line.match(/Found (\d+) errors?\./)
-            if (summaryMatch) {
-              const errorCount = +summaryMatch[1]!
-              if (overlay) {
-                parentPort?.postMessage({
-                  type: ACTION_TYPES.overlayError,
-                  payload: toClientPayload('typescript', currDiagnostics),
-                })
-              }
-              // Capture logChunk before resetting — ensureCall defers via setTimeout
-              const capturedLogChunk = logChunk
-              ensureCall(() => {
-                if (terminal) {
-                  const color = errorCount > 0 ? 'red' : 'green'
-                  consoleLog(
-                    colors[color](
-                      (errorCount > 0 ? capturedLogChunk : '') +
-                        os.EOL +
-                        wrapCheckerSummary(
-                          'TypeScript',
-                          errorCount > 0
-                            ? `Found ${errorCount} error(s)`
-                            : 'No errors',
-                        ),
-                    ),
-                    errorCount > 0 ? 'error' : 'info',
-                  )
-                }
-              })
-              logChunk = ''
-              currDiagnostics = []
+            pendingDiag = {
+              message: `TS${tsCode}: ${message}`,
+              conclusion: '',
+              id: absFile,
+              checker: 'TypeScript',
+              codeFrame,
+              stripedCodeFrame,
+              loc: {
+                start: { line: lineNum, column: colNum },
+              },
+              level:
+                severity === 'warning'
+                  ? DiagnosticLevel.Warning
+                  : DiagnosticLevel.Error,
             }
+            return
           }
+
+          // Parse: "Found X errors." or "Found X errors. Watching for file changes."
+          const summaryMatch = line.match(/Found (\d+) errors?\./)
+          if (summaryMatch) {
+            flushPendingDiag()
+            const errorCount = +summaryMatch[1]!
+            if (overlay) {
+              parentPort?.postMessage({
+                type: ACTION_TYPES.overlayError,
+                payload: toClientPayload('typescript', currDiagnostics),
+              })
+            }
+            // Capture logChunk before resetting; ensureCall defers via setTimeout
+            const capturedLogChunk = logChunk
+            ensureCall(() => {
+              if (terminal) {
+                const color = errorCount > 0 ? 'red' : 'green'
+                consoleLog(
+                  colors[color](
+                    (errorCount > 0 ? capturedLogChunk : '') +
+                      os.EOL +
+                      wrapCheckerSummary(
+                        'TypeScript',
+                        errorCount > 0
+                          ? `Found ${errorCount} error(s)`
+                          : 'No errors',
+                      ),
+                  ),
+                  errorCount > 0 ? 'error' : 'info',
+                )
+              }
+            })
+            logChunk = ''
+            currDiagnostics = []
+            return
+          }
+
+          // A non-empty, non-summary line while a diagnostic is open is a
+          // continuation of its (multi-line) message.
+          if (pendingDiag && line.trim() !== '') {
+            pendingDiag.message += os.EOL + line
+          }
+        }
+
+        tscProcess.stdout.on('data', (chunk: Buffer) => {
+          stdoutBuffer += chunk.toString()
+          const lines = stdoutBuffer.split('\n')
+          stdoutBuffer = lines.pop() ?? ''
+          for (const rawLine of lines) handleLine(rawLine)
+        })
+
+        tscProcess.stderr.on('data', (chunk: Buffer) => {
+          consoleLog(colors.red(chunk.toString()), 'error')
         })
 
         tscProcess.on('error', (err: Error) => {
@@ -194,10 +247,11 @@ const createDiagnostic: CreateDiagnostic<'typescript'> = (pluginConfig) => {
           )
         })
 
-        // Cleanup on worker exit
-        parentPort?.on('close', () => {
+        const killTsc = () => {
           tscProcess.kill()
-        })
+        }
+        parentPort?.on('close', killTsc)
+        process.on('exit', killTsc)
 
         return
       }

--- a/packages/vite-plugin-checker/src/checkers/typescript/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/typescript/main.ts
@@ -7,6 +7,7 @@ import invariant from 'tiny-invariant'
 import type * as typescript from 'typescript'
 
 import { Checker } from '../../Checker.js'
+import { createFrame } from '../../codeFrame.js'
 import {
   consoleLog,
   diagnosticToRuntimeError,
@@ -68,7 +69,8 @@ const createDiagnostic: CreateDiagnostic<'typescript'> = (pluginConfig) => {
 
       if (isTsV7) {
         const { spawn } = await import('node:child_process')
-        const { existsSync } = await import('node:fs')
+        const { existsSync, readFileSync } = await import('node:fs')
+        const { stripVTControlCharacters: strip } = await import('node:util')
 
         const tsconfigPath = path.resolve(
           finalConfig.root,
@@ -95,20 +97,49 @@ const createDiagnostic: CreateDiagnostic<'typescript'> = (pluginConfig) => {
 
         tscProcess.stdout.on('data', (chunk: Buffer) => {
           const lines = chunk.toString().split('\n')
-          for (const line of lines) {
-            // Parse: "<file>:<line>:<col> - error TS<code>: <message>"
+          for (const rawLine of lines) {
+            // Strip \r and timestamp prefix that tsc --watch prepends to each line
+            const line = rawLine
+              .replace(/\r$/, '')
+              .replace(/^\d{1,2}:\d{2}:\d{2}\s+[AP]M\s+-\s+/, '')
+
+            // Parse: "<file>(<line>,<col>): error TS<code>: <message>"
+            // This is the --pretty false format; the pretty format uses
+            // "<file>:<line>:<col> - error TS<code>: <message>" instead.
             const diagMatch = line.match(
-              /^(.+?):(\d+):(\d+) - (error|warning) TS(\d+): (.+)$/,
+              /^(.+?)\((\d+),(\d+)\): (error|warning) TS(\d+): (.+)$/,
             )
             if (diagMatch) {
-              const [, file, lineStr, colStr, severity, , message] = diagMatch
+              const [, file, lineStr, colStr, severity, tsCode, message] =
+                diagMatch
+              const lineNum = +lineStr!
+              const colNum = +colStr!
+
+              // tsc outputs paths relative to its cwd (finalConfig.root);
+              // resolve to absolute so readFileSync works in the worker thread
+              const absFile = path.resolve(finalConfig.root, file!)
+
+              let codeFrame: string | undefined
+              let stripedCodeFrame: string | undefined
+              if (existsSync(absFile)) {
+                try {
+                  const source = readFileSync(absFile, 'utf-8')
+                  codeFrame = createFrame(source, {
+                    start: { line: lineNum, column: colNum },
+                  })
+                  stripedCodeFrame = strip(codeFrame)
+                } catch {}
+              }
+
               const normalized: NormalizedDiagnostic = {
-                message: message!,
+                message: `TS${tsCode}: ${message}`,
                 conclusion: '',
-                id: file,
+                id: absFile,
                 checker: 'TypeScript',
+                codeFrame,
+                stripedCodeFrame,
                 loc: {
-                  start: { line: +lineStr!, column: +colStr! },
+                  start: { line: lineNum, column: colNum },
                 },
                 level:
                   severity === 'warning'
@@ -120,7 +151,7 @@ const createDiagnostic: CreateDiagnostic<'typescript'> = (pluginConfig) => {
                 os.EOL + diagnosticToTerminalLog(normalized, 'TypeScript')
             }
 
-            // Parse: "Found X errors."
+            // Parse: "Found X errors." or "Found X errors. Watching for file changes."
             const summaryMatch = line.match(/Found (\d+) errors?\./)
             if (summaryMatch) {
               const errorCount = +summaryMatch[1]!
@@ -130,13 +161,14 @@ const createDiagnostic: CreateDiagnostic<'typescript'> = (pluginConfig) => {
                   payload: toClientPayload('typescript', currDiagnostics),
                 })
               }
+              // Capture logChunk before resetting — ensureCall defers via setTimeout
+              const capturedLogChunk = logChunk
               ensureCall(() => {
-                if (errorCount === 0) logChunk = ''
                 if (terminal) {
                   const color = errorCount > 0 ? 'red' : 'green'
                   consoleLog(
                     colors[color](
-                      logChunk +
+                      (errorCount > 0 ? capturedLogChunk : '') +
                         os.EOL +
                         wrapCheckerSummary(
                           'TypeScript',

--- a/packages/vite-plugin-checker/src/checkers/typescript/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/typescript/main.ts
@@ -12,6 +12,7 @@ import {
   diagnosticToRuntimeError,
   diagnosticToTerminalLog,
   ensureCall,
+  type NormalizedDiagnostic,
   normalizeTsDiagnostic,
   toClientPayload,
   wrapCheckerSummary,
@@ -19,6 +20,7 @@ import {
 import {
   ACTION_TYPES,
   type CreateDiagnostic,
+  DiagnosticLevel,
   type DiagnosticToRuntime,
 } from '../../types.js'
 import { forceNoEmitOnSolutionBuilderHost } from '../tscUtils.js'
@@ -57,6 +59,117 @@ const createDiagnostic: CreateDiagnostic<'typescript'> = (pluginConfig) => {
       const ts: typeof typescript = await import(
         finalConfig.typescriptPath
       ).then((r) => r.default || r)
+
+      // TS v7 (Corsa) removed the entire ts namespace from the root import.
+      // `ts.sys`, `ts.findConfigFile()`, `ts.createWatchCompilerHost()`, etc.
+      // are gone. Fall back to spawning `tsc --noEmit --watch` as a child
+      // process and parse its stdout for diagnostics.
+      const isTsV7 = !ts.sys
+
+      if (isTsV7) {
+        const { spawn } = await import('node:child_process')
+        const { existsSync } = await import('node:fs')
+
+        const tsconfigPath = path.resolve(
+          finalConfig.root,
+          finalConfig.tsconfigPath,
+        )
+        if (!existsSync(tsconfigPath)) {
+          throw new Error(`Failed to find tsconfig.json: ${tsconfigPath}`)
+        }
+
+        const isBuildMode =
+          typeof pluginConfig.typescript === 'object' &&
+          pluginConfig.typescript.buildMode
+        const args = [
+          ...(isBuildMode ? ['-b'] : ['--noEmit']),
+          '--watch',
+          '--pretty',
+          'false',
+        ]
+        args.push('-p', tsconfigPath)
+
+        const tscProcess = spawn('tsc', args, { cwd: finalConfig.root })
+
+        let logChunk = ''
+
+        tscProcess.stdout.on('data', (chunk: Buffer) => {
+          const lines = chunk.toString().split('\n')
+          for (const line of lines) {
+            // Parse: "<file>:<line>:<col> - error TS<code>: <message>"
+            const diagMatch = line.match(
+              /^(.+?):(\d+):(\d+) - (error|warning) TS(\d+): (.+)$/,
+            )
+            if (diagMatch) {
+              const [, file, lineStr, colStr, severity, , message] = diagMatch
+              const normalized: NormalizedDiagnostic = {
+                message: message!,
+                conclusion: '',
+                id: file,
+                checker: 'TypeScript',
+                loc: {
+                  start: { line: +lineStr!, column: +colStr! },
+                },
+                level:
+                  severity === 'warning'
+                    ? DiagnosticLevel.Warning
+                    : DiagnosticLevel.Error,
+              }
+              currDiagnostics.push(diagnosticToRuntimeError(normalized))
+              logChunk +=
+                os.EOL + diagnosticToTerminalLog(normalized, 'TypeScript')
+            }
+
+            // Parse: "Found X errors."
+            const summaryMatch = line.match(/Found (\d+) errors?\./)
+            if (summaryMatch) {
+              const errorCount = +summaryMatch[1]!
+              if (overlay) {
+                parentPort?.postMessage({
+                  type: ACTION_TYPES.overlayError,
+                  payload: toClientPayload('typescript', currDiagnostics),
+                })
+              }
+              ensureCall(() => {
+                if (errorCount === 0) logChunk = ''
+                if (terminal) {
+                  const color = errorCount > 0 ? 'red' : 'green'
+                  consoleLog(
+                    colors[color](
+                      logChunk +
+                        os.EOL +
+                        wrapCheckerSummary(
+                          'TypeScript',
+                          errorCount > 0
+                            ? `Found ${errorCount} error(s)`
+                            : 'No errors',
+                        ),
+                    ),
+                    errorCount > 0 ? 'error' : 'info',
+                  )
+                }
+              })
+              logChunk = ''
+              currDiagnostics = []
+            }
+          }
+        })
+
+        tscProcess.on('error', (err: Error) => {
+          consoleLog(
+            colors.red(`TypeScript checker failed: ${err.message}`),
+            'error',
+          )
+        })
+
+        // Cleanup on worker exit
+        parentPort?.on('close', () => {
+          tscProcess.kill()
+        })
+
+        return
+      }
+
       configFile = ts.findConfigFile(
         finalConfig.root,
         ts.sys.fileExists,

--- a/packages/vite-plugin-checker/src/checkers/typescript/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/typescript/main.ts
@@ -104,18 +104,33 @@ const createDiagnostic: CreateDiagnostic<'typescript'> = (pluginConfig) => {
           const requireFromRoot = createRequire(
             path.join(finalConfig.root, 'noop.js'),
           )
-          const tsPkgJson = requireFromRoot.resolve(
-            `${finalConfig.typescriptPath}/package.json`,
-          )
-          tscBin = path.join(path.dirname(tsPkgJson), 'bin', 'tsc')
+          // `typescriptPath` may be a bare specifier ('typescript') or an
+          // absolute path to the module entry, so resolve the entry first and
+          // walk up to the nearest package.json to locate `bin/tsc`.
+          const tsEntry = requireFromRoot.resolve(finalConfig.typescriptPath)
+          let dir = path.dirname(tsEntry)
+          while (dir !== path.dirname(dir)) {
+            if (existsSync(path.join(dir, 'package.json'))) break
+            dir = path.dirname(dir)
+          }
+          tscBin = path.join(dir, 'bin', 'tsc')
           runWithNode = existsSync(tscBin)
         } catch {}
 
+        // Silence the child's own Node warnings (e.g. experimental-feature
+        // notices) so they don't get surfaced as checker diagnostics; tsc
+        // reports through stdout, stderr is reserved for real failures.
+        const tscEnv = { ...process.env, NODE_NO_WARNINGS: '1' }
         const tscProcess = runWithNode
           ? spawn(process.execPath, [tscBin, ...args], {
               cwd: finalConfig.root,
+              env: tscEnv,
             })
-          : spawn(tscBin, args, { cwd: finalConfig.root, shell: true })
+          : spawn(tscBin, args, {
+              cwd: finalConfig.root,
+              env: tscEnv,
+              shell: true,
+            })
 
         let logChunk = ''
 

--- a/playground/typescript-7/__tests__/__snapshots__/test.spec.ts.snap
+++ b/playground/typescript-7/__tests__/__snapshots__/test.spec.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`typescript-7 > serve > get initial error and subsequent error 1`] = `"[{"checkerId":"TypeScript","frame":"    3 | }/n    4 |/n  > 5 | const count: number = 'not a number'/n      |       ^/n    6 |/n    7 | document.querySelector('#app')!.textContent = greet('Vite') + count/n    8 |","id":"<PROJECT_ROOT>/playground-temp/typescript-7/src/main.ts","level":1,"loc":{"column":7,"file":"<PROJECT_ROOT>/playground-temp/typescript-7/src/main.ts","line":5},"message":"TS2322: Type 'string' is not assignable to type 'number'.","stack":""}]"`;
+
+exports[`typescript-7 > serve > get initial error and subsequent error 2`] = `
+[
+  "
+ ERROR(TypeScript)  TS2322: Type 'string' is not assignable to type 'number'.
+ FILE  <PROJECT_ROOT>/playground-temp/typescript-7/src/main.ts:5:7
+
+    3 | }
+    4 |
+  > 5 | const count: number = 'not a number'
+      |       ^
+    6 |
+    7 | document.querySelector('#app')!.textContent = greet('Vite') + count
+    8 |
+
+[TypeScript] Found 1 error(s)",
+]
+`;
+
+exports[`typescript-7 > serve > get initial error and subsequent error 3`] = `"[{"checkerId":"TypeScript","frame":"    3 | }/n    4 |/n  > 5 | const count: number = 'still not a number'/n      |       ^/n    6 |/n    7 | document.querySelector('#app')!.textContent = greet('Vite') + count/n    8 |","id":"<PROJECT_ROOT>/playground-temp/typescript-7/src/main.ts","level":1,"loc":{"column":7,"file":"<PROJECT_ROOT>/playground-temp/typescript-7/src/main.ts","line":5},"message":"TS2322: Type 'string' is not assignable to type 'number'.","stack":""}]"`;
+
+exports[`typescript-7 > serve > get initial error and subsequent error 4`] = `
+[
+  "
+ ERROR(TypeScript)  TS2322: Type 'string' is not assignable to type 'number'.
+ FILE  <PROJECT_ROOT>/playground-temp/typescript-7/src/main.ts:5:7
+
+    3 | }
+    4 |
+  > 5 | const count: number = 'still not a number'
+      |       ^
+    6 |
+    7 | document.querySelector('#app')!.textContent = greet('Vite') + count
+    8 |
+
+[TypeScript] Found 1 error(s)",
+]
+`;

--- a/playground/typescript-7/__tests__/test.spec.ts
+++ b/playground/typescript-7/__tests__/test.spec.ts
@@ -1,0 +1,40 @@
+import stringify from 'fast-json-stable-stringify'
+import { describe, expect, it } from 'vitest'
+
+import {
+  diagnostics,
+  editFile,
+  expectStderrContains,
+  isBuild,
+  isServe,
+  log,
+  resetReceivedLog,
+  sleepForServerReady,
+  stripedLog,
+  waitForDiagnostics,
+} from '../../testUtils'
+
+describe('typescript-7', () => {
+  describe.runIf(isServe)('serve', () => {
+    it('get initial error and subsequent error', async () => {
+      await sleepForServerReady()
+      expect(stringify(diagnostics)).toMatchSnapshot()
+      expect(stripedLog).toMatchSnapshot()
+
+      console.log('-- edit file --')
+      resetReceivedLog()
+      editFile('src/main.ts', (code) =>
+        code.replace("'not a number'", "'still not a number'"),
+      )
+      await waitForDiagnostics()
+      expect(stringify(diagnostics)).toMatchSnapshot()
+      expect(stripedLog).toMatchSnapshot()
+    })
+  })
+
+  describe.runIf(isBuild)('build', () => {
+    it('should fail', async () => {
+      expectStderrContains(log, 'TS2322')
+    })
+  })
+})

--- a/playground/typescript-7/index.html
+++ b/playground/typescript-7/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite App</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/playground/typescript-7/package.json
+++ b/playground/typescript-7/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@playground/typescript-7",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite",
+    "serve": "vite preview"
+  },
+  "devDependencies": {
+    "typescript": "^7.0.2",
+    "vite": "^8.0.9",
+    "vite-plugin-checker": "workspace:*"
+  }
+}

--- a/playground/typescript-7/src/main.ts
+++ b/playground/typescript-7/src/main.ts
@@ -1,0 +1,7 @@
+export function greet(name: string): string {
+  return `Hello, ${name}!`
+}
+
+const count: number = 'not a number'
+
+document.querySelector('#app')!.textContent = greet('Vite') + count

--- a/playground/typescript-7/tsconfig.json
+++ b/playground/typescript-7/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "types": ["vite/client"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./src"]
+}

--- a/playground/typescript-7/vite.config.js
+++ b/playground/typescript-7/vite.config.js
@@ -1,0 +1,19 @@
+import { createRequire } from 'node:module'
+import { defineConfig } from 'vite'
+import checker from 'vite-plugin-checker'
+
+// TS 7 (the native port) dropped the JS `ts` namespace API the checker uses,
+// so point `typescriptPath` at this project's own v7 install to exercise the
+// child-process `tsc --watch` fallback path.
+const require = createRequire(import.meta.url)
+const typescriptPath = require.resolve('typescript')
+
+export default defineConfig({
+  plugins: [
+    checker({
+      typescript: {
+        typescriptPath,
+      },
+    }),
+  ],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,7 +76,7 @@ importers:
     dependencies:
       vitepress:
         specifier: ^1.6.4
-        version: 1.6.4(@algolia/client-search@5.34.1)(@types/node@20.19.9)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@5.9.3)
+        version: 1.6.4(@algolia/client-search@5.34.1)(@types/node@20.19.9)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@7.0.2)
 
   packages/runtime:
     devDependencies:
@@ -500,6 +500,18 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vite:
+        specifier: ^8.0.9
+        version: 8.0.16(@types/node@20.19.9)(jiti@2.7.0)(yaml@2.9.0)
+      vite-plugin-checker:
+        specifier: workspace:*
+        version: link:../../packages/vite-plugin-checker
+
+  playground/typescript-7:
+    devDependencies:
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
       vite:
         specifier: ^8.0.9
         version: 8.0.16(@types/node@20.19.9)(jiti@2.7.0)(yaml@2.9.0)
@@ -1982,6 +1994,126 @@ packages:
   '@typescript-eslint/visitor-keys@8.61.0':
     resolution: {integrity: sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -3622,6 +3754,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
   unbash@3.0.0:
     resolution: {integrity: sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA==}
     engines: {node: '>=14'}
@@ -4944,6 +5081,66 @@ snapshots:
       '@typescript-eslint/types': 8.61.0
       eslint-visitor-keys: 5.0.1
 
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
   '@ungap/structured-clone@1.3.0': {}
 
   '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@20.19.9)(jiti@2.7.0)(yaml@2.9.0))':
@@ -4951,10 +5148,10 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@20.19.9)(jiti@2.7.0)(yaml@2.9.0)
 
-  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@20.19.9)(lightningcss@1.32.0))(vue@3.5.29(typescript@5.9.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@20.19.9)(lightningcss@1.32.0))(vue@3.5.29(typescript@7.0.2))':
     dependencies:
       vite: 5.4.21(@types/node@20.19.9)(lightningcss@1.32.0)
-      vue: 3.5.29(typescript@5.9.3)
+      vue: 3.5.29(typescript@7.0.2)
 
   '@vitejs/plugin-vue@6.0.7(vite@8.0.16(@types/node@20.19.9)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.38(typescript@5.8.3))':
     dependencies:
@@ -5141,11 +5338,11 @@ snapshots:
       '@vue/shared': 3.5.38
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.29(vue@3.5.29(typescript@5.9.3))':
+  '@vue/server-renderer@3.5.29(vue@3.5.29(typescript@7.0.2))':
     dependencies:
       '@vue/compiler-ssr': 3.5.29
       '@vue/shared': 3.5.29
-      vue: 3.5.29(typescript@5.9.3)
+      vue: 3.5.29(typescript@7.0.2)
 
   '@vue/server-renderer@3.5.38(vue@3.5.38(typescript@5.8.3))':
     dependencies:
@@ -5163,20 +5360,20 @@ snapshots:
 
   '@vue/shared@3.5.38': {}
 
-  '@vueuse/core@12.8.2(typescript@5.9.3)':
+  '@vueuse/core@12.8.2(typescript@7.0.2)':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 12.8.2
-      '@vueuse/shared': 12.8.2(typescript@5.9.3)
-      vue: 3.5.29(typescript@5.9.3)
+      '@vueuse/shared': 12.8.2(typescript@7.0.2)
+      vue: 3.5.29(typescript@7.0.2)
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/integrations@12.8.2(focus-trap@7.6.5)(typescript@5.9.3)':
+  '@vueuse/integrations@12.8.2(focus-trap@7.6.5)(typescript@7.0.2)':
     dependencies:
-      '@vueuse/core': 12.8.2(typescript@5.9.3)
-      '@vueuse/shared': 12.8.2(typescript@5.9.3)
-      vue: 3.5.29(typescript@5.9.3)
+      '@vueuse/core': 12.8.2(typescript@7.0.2)
+      '@vueuse/shared': 12.8.2(typescript@7.0.2)
+      vue: 3.5.29(typescript@7.0.2)
     optionalDependencies:
       focus-trap: 7.6.5
     transitivePeerDependencies:
@@ -5184,9 +5381,9 @@ snapshots:
 
   '@vueuse/metadata@12.8.2': {}
 
-  '@vueuse/shared@12.8.2(typescript@5.9.3)':
+  '@vueuse/shared@12.8.2(typescript@7.0.2)':
     dependencies:
-      vue: 3.5.29(typescript@5.9.3)
+      vue: 3.5.29(typescript@7.0.2)
     transitivePeerDependencies:
       - typescript
 
@@ -6779,6 +6976,29 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
+
   unbash@3.0.0: {}
 
   unconfig-core@7.5.0:
@@ -6858,7 +7078,7 @@ snapshots:
       jiti: 2.7.0
       yaml: 2.9.0
 
-  vitepress@1.6.4(@algolia/client-search@5.34.1)(@types/node@20.19.9)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@5.9.3):
+  vitepress@1.6.4(@algolia/client-search@5.34.1)(@types/node@20.19.9)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@7.0.2):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.34.1)
@@ -6867,17 +7087,17 @@ snapshots:
       '@shikijs/transformers': 2.5.0
       '@shikijs/types': 2.5.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@20.19.9)(lightningcss@1.32.0))(vue@3.5.29(typescript@5.9.3))
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@20.19.9)(lightningcss@1.32.0))(vue@3.5.29(typescript@7.0.2))
       '@vue/devtools-api': 7.7.7
       '@vue/shared': 3.5.29
-      '@vueuse/core': 12.8.2(typescript@5.9.3)
-      '@vueuse/integrations': 12.8.2(focus-trap@7.6.5)(typescript@5.9.3)
+      '@vueuse/core': 12.8.2(typescript@7.0.2)
+      '@vueuse/integrations': 12.8.2(focus-trap@7.6.5)(typescript@7.0.2)
       focus-trap: 7.6.5
       mark.js: 8.11.1
       minisearch: 7.1.2
       shiki: 2.5.0
       vite: 5.4.21(@types/node@20.19.9)(lightningcss@1.32.0)
-      vue: 3.5.29(typescript@5.9.3)
+      vue: 3.5.29(typescript@7.0.2)
     optionalDependencies:
       postcss: 8.5.15
     transitivePeerDependencies:
@@ -6948,15 +7168,15 @@ snapshots:
       '@vue/language-core': 3.3.4
       typescript: 5.9.3
 
-  vue@3.5.29(typescript@5.9.3):
+  vue@3.5.29(typescript@7.0.2):
     dependencies:
       '@vue/compiler-dom': 3.5.29
       '@vue/compiler-sfc': 3.5.29
       '@vue/runtime-dom': 3.5.29
-      '@vue/server-renderer': 3.5.29(vue@3.5.29(typescript@5.9.3))
+      '@vue/server-renderer': 3.5.29(vue@3.5.29(typescript@7.0.2))
       '@vue/shared': 3.5.29
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 7.0.2
 
   vue@3.5.38(typescript@5.8.3):
     dependencies:


### PR DESCRIPTION
Hi,

In this PR we are addressing the fact that trying to use `vite-plugin-checker` with Typescript 7 leads to a fatal error preventing starting the actual serve process using this plugin. In such case the error thrown looks like this:

```
node:internal/event_target:1136
  process.nextTick(() => { throw err; });
                           ^
TypeError: Cannot read properties of undefined (reading 'fileExists')
    at Object.configureServer (file:///[...]/app-react/node_modules/vite-plugin-checker/dist/checkers/typescript/main.js:36:60)

Node.js v26.5.0
error: script "start" exited with code 1
```

Here is the fix that checks if the original TS < 7 API is available. If it is, it should preserve previous behaviour. If it's not however, then spawn `tsc --noEmit --watch` as a child process and parse its stdout for diagnostics.
This looked like a least problematic approach

How it looks in action: (my app, added a TS error on purpose)
```
  VITE v8.1.4  ready in 157 ms

  ➜  Local:   http://localhost:3052/
  ➜  press h + enter to show help
12:23:23 [vite] (client) [optimizer] bundling dependencies...

 ERROR(TypeScript)  TS2304: Cannot find name 'nonexisten'.
 FILE  [...]/app-react/src/app/auth/interceptor.ts:10:39

     8 |
     9 | export function shouldAddAuthToken(url?: string): boolean {
  > 10 |   if (!url || !url.startsWith('/') || nonexisten) {
       |                                       ^
    11 |     return false;
    12 |   }
    13 |

[TypeScript] Found 1 error(s)
```