### PR TITLE
fix(typescript,vueTsc): quote the project path passed to tsc

### DIFF
--- a/packages/vite-plugin-checker/__tests__/utils.spec.ts
+++ b/packages/vite-plugin-checker/__tests__/utils.spec.ts
@@ -1,6 +1,21 @@
+import { spawnSync } from 'node:child_process'
 import { describe, expect, it } from 'vitest'
 
-import { ignoreTransientFsError, isTransientFsError } from '../src/utils'
+import {
+  ignoreTransientFsError,
+  isTransientFsError,
+  quoteShellArg,
+} from '../src/utils'
+
+function withPlatform(platform: NodeJS.Platform, run: () => void) {
+  const descriptor = Object.getOwnPropertyDescriptor(process, 'platform')!
+  Object.defineProperty(process, 'platform', { ...descriptor, value: platform })
+  try {
+    run()
+  } finally {
+    Object.defineProperty(process, 'platform', descriptor)
+  }
+}
 
 const fsError = (code: string) => Object.assign(new Error(code), { code })
 
@@ -33,4 +48,53 @@ describe('ignoreTransientFsError', () => {
     const error = fsError('EISDIR')
     expect(() => ignoreTransientFsError(error)).toThrow(error)
   })
+})
+
+describe('quoteShellArg', () => {
+  it('keeps a path containing spaces in one argument', () => {
+    withPlatform('linux', () => {
+      expect(quoteShellArg('/repo/my apps/tsconfig.json')).toBe(
+        "'/repo/my apps/tsconfig.json'",
+      )
+    })
+  })
+
+  it('escapes quotes that the path itself contains', () => {
+    withPlatform('linux', () => {
+      expect(quoteShellArg("/repo/it's/tsconfig.json")).toBe(
+        "'/repo/it'\\''s/tsconfig.json'",
+      )
+    })
+
+    withPlatform('win32', () => {
+      expect(quoteShellArg('C:\\my apps\\tsconfig.json')).toBe(
+        '"C:\\my apps\\tsconfig.json"',
+      )
+    })
+  })
+
+  it('leaves an empty argument alone', () => {
+    expect(quoteShellArg('')).toBe('')
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'survives a round trip through a real shell',
+    () => {
+      const target = '/repo/my apps/tsconfig.json'
+      const command = [
+        quoteShellArg(process.execPath),
+        '-e',
+        quoteShellArg('console.log(JSON.stringify(process.argv.slice(1)))'),
+        quoteShellArg(target),
+      ].join(' ')
+
+      const { stdout, status } = spawnSync(command, {
+        shell: true,
+        encoding: 'utf8',
+      })
+
+      expect(status).toBe(0)
+      expect(JSON.parse(stdout)).toEqual([target])
+    },
+  )
 })

--- a/packages/vite-plugin-checker/src/checkers/typescript/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/typescript/main.ts
@@ -24,6 +24,7 @@ import {
   DiagnosticLevel,
   type DiagnosticToRuntime,
 } from '../../types.js'
+import { quoteShellArg } from '../../utils.js'
 import { forceNoEmitOnSolutionBuilderHost } from '../tscUtils.js'
 
 const __filename = fileURLToPath(import.meta.url)
@@ -129,7 +130,9 @@ const createDiagnostic: CreateDiagnostic<'typescript'> = (pluginConfig) => {
               cwd: finalConfig.root,
               env: tscEnv,
             })
-          : spawn(tscBin, args, {
+          : // Falling back to `tsc` from PATH needs a shell, which splits the
+            // arguments on whitespace unless they are quoted.
+            spawn(tscBin, args.map(quoteShellArg), {
               cwd: finalConfig.root,
               env: tscEnv,
               shell: true,
@@ -412,9 +415,9 @@ export class TscChecker extends Checker<'typescript'> {
             if (projectPath) {
               // In build mode, the tsconfig path is an argument to -b, e.g. "tsc -b [path]"
               if (buildMode) {
-                args.push(projectPath)
+                args.push(quoteShellArg(projectPath))
               } else {
-                args.push('-p', projectPath)
+                args.push('-p', quoteShellArg(projectPath))
               }
             }
 

--- a/packages/vite-plugin-checker/src/checkers/vueTsc/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/vueTsc/main.ts
@@ -21,6 +21,7 @@ import {
   type CreateDiagnostic,
   type DiagnosticToRuntime,
 } from '../../types.js'
+import { quoteShellArg } from '../../utils.js'
 import { forceNoEmitOnSolutionBuilderHost } from '../tscUtils.js'
 import { prepareVueTsc } from './prepareVueTsc.js'
 
@@ -185,9 +186,9 @@ export class VueTscChecker extends Checker<'vueTsc'> {
             if (projectPath) {
               // In build mode, the tsconfig path is an argument to -b, e.g. "vue-tsc -b [path]"
               if (buildMode) {
-                args.push(projectPath)
+                args.push(quoteShellArg(projectPath))
               } else {
-                args.push('-p', projectPath)
+                args.push('-p', quoteShellArg(projectPath))
               }
             }
 

--- a/packages/vite-plugin-checker/src/utils.ts
+++ b/packages/vite-plugin-checker/src/utils.ts
@@ -28,3 +28,20 @@ export function ignoreTransientFsError(error: unknown): void {
   if (isTransientFsError(error)) return
   throw error
 }
+
+// Checker binaries are spawned through a shell (see `spawnChecker`), which
+// means every argument the plugin builds itself has to survive word splitting.
+// Paths are what bite: a project under "my apps/site" would otherwise reach the
+// binary as two arguments, and `tsc -p "my apps/site/tsconfig.json"` fails with
+// "TS5042: Option 'project' cannot be mixed with source files on a command
+// line". Quote per platform: cmd.exe understands double quotes only, while
+// POSIX shells would keep expanding `$` and backticks inside them.
+export function quoteShellArg(arg: string): string {
+  if (arg === '') return arg
+
+  if (process.platform === 'win32') {
+    return `"${arg.replace(/"/g, '\\"')}"`
+  }
+
+  return `'${arg.replace(/'/g, `'\\''`)}'`
+}


### PR DESCRIPTION
Checker binaries are spawned through a shell, which splits the command on whitespace. The typescript and vueTsc checkers build the project path themselves from `root` and `tsconfigPath`, so a project living under a directory with a space in its name reached tsc as two arguments and failed with "TS5042: Option 'project' cannot be mixed with source files on a command line".

Quote the constructed path, per platform, since cmd.exe understands only double quotes while POSIX shells keep expanding inside them. Arguments that come from a user supplied `lintCommand` are left untouched: they are already split on spaces and carry their own quoting.

The same splitting applied to the fallback that runs `tsc` from PATH when the TypeScript package exposes no compiler API, as with TypeScript 7, so quote those arguments as well.