### PR TITLE
fix: run checker binaries without a shell

### DIFF
--- a/packages/vite-plugin-checker/__tests__/buildBin.spec.ts
+++ b/packages/vite-plugin-checker/__tests__/buildBin.spec.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import spawn from 'cross-spawn'
 import { describe, expect, it } from 'vitest'
 
@@ -72,10 +73,10 @@ describe('typescript buildBin', () => {
   const checker = new TscChecker()
 
   it('leaves a project path containing a space untouched', () => {
-    const [, args] = buildBin(checker, {
-      typescript: { root: '/repo/my project' },
-    })
-    expect(args).toEqual(['--noEmit', '-p', '/repo/my project'])
+    // The checker joins the path itself, so the separators are the platform's.
+    const root = path.normalize('/repo/my project')
+    const [, args] = buildBin(checker, { typescript: { root } })
+    expect(args).toEqual(['--noEmit', '-p', root])
   })
 })
 

--- a/packages/vite-plugin-checker/__tests__/buildBin.spec.ts
+++ b/packages/vite-plugin-checker/__tests__/buildBin.spec.ts
@@ -1,0 +1,94 @@
+import spawn from 'cross-spawn'
+import { describe, expect, it } from 'vitest'
+
+import { BiomeChecker } from '../src/checkers/biome/main'
+import { EslintChecker } from '../src/checkers/eslint/main'
+import { StylelintChecker } from '../src/checkers/stylelint/main'
+import { TscChecker } from '../src/checkers/typescript/main'
+
+// The checkers hand their command to `spawn` as a list of arguments, without a
+// shell. Every element therefore has to be one whole argument: quotes are
+// stripped here, a quoted argument stays in one piece, and an empty argument is
+// never passed.
+const buildBin = (checker: { build: { buildBin: any } }, config: any) =>
+  checker.build.buildBin(config)
+
+describe('eslint buildBin', () => {
+  const checker = new EslintChecker()
+
+  it('splits the lint command into separate arguments', () => {
+    expect(
+      buildBin(checker, { eslint: { lintCommand: 'eslint --ext .ts src' } }),
+    ).toEqual(['eslint', ['--ext', '.ts', 'src']])
+  })
+
+  it('keeps a quoted glob as one argument, without its quotes', () => {
+    const [, args] = buildBin(checker, {
+      eslint: { lintCommand: 'eslint "src/my components/**/*.ts"' },
+    })
+    expect(args).toEqual(['src/my components/**/*.ts'])
+  })
+
+  it('passes no arguments at all when there is no command', () => {
+    expect(buildBin(checker, {})).toEqual(['eslint', []])
+  })
+})
+
+describe('stylelint buildBin', () => {
+  const checker = new StylelintChecker()
+
+  it('keeps a quoted glob as one argument, without its quotes', () => {
+    const [, args] = buildBin(checker, {
+      stylelint: { lintCommand: 'stylelint "src/my styles/**/*.css"' },
+    })
+    expect(args).toEqual(['src/my styles/**/*.css'])
+  })
+
+  it('passes no arguments at all when there is no command', () => {
+    expect(buildBin(checker, {})).toEqual(['stylelint', []])
+  })
+})
+
+describe('biome buildBin', () => {
+  const checker = new BiomeChecker()
+
+  it('splits the flags string into separate arguments', () => {
+    expect(
+      buildBin(checker, {
+        biome: { command: 'lint', flags: '--write --error-on-warnings' },
+      }),
+    ).toEqual(['biome', ['lint', '--write', '--error-on-warnings']])
+  })
+
+  it('does not pass an empty argument when there are no flags', () => {
+    expect(buildBin(checker, { biome: { command: 'check' } })).toEqual([
+      'biome',
+      ['check'],
+    ])
+  })
+})
+
+describe('typescript buildBin', () => {
+  const checker = new TscChecker()
+
+  it('leaves a project path containing a space untouched', () => {
+    const [, args] = buildBin(checker, {
+      typescript: { root: '/repo/my project' },
+    })
+    expect(args).toEqual(['--noEmit', '-p', '/repo/my project'])
+  })
+})
+
+describe('spawning a command built this way', () => {
+  it('delivers an argument containing a space as one argument', () => {
+    const target = '/repo/my project/tsconfig.json'
+    const result = spawn.sync(
+      process.execPath,
+      ['-e', 'console.log(JSON.stringify(process.argv.slice(1)))', target],
+      { encoding: 'utf8' },
+    )
+
+    expect(result.status).toBe(0)
+    expect(JSON.parse(result.stdout)).toEqual([target])
+  })
+})

--- a/packages/vite-plugin-checker/package.json
+++ b/packages/vite-plugin-checker/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@babel/code-frame": "^7.29.0",
     "chokidar": "^5.0.0",
+    "cross-spawn": "^7.0.6",
     "npm-run-path": "^6.0.0",
     "picocolors": "^1.1.1",
     "picomatch": "^4.0.4",
@@ -43,6 +44,7 @@
     "tiny-invariant": "^1.3.3"
   },
   "devDependencies": {
+    "@types/cross-spawn": "^6.0.6",
     "@types/picomatch": "^4.0.3",
     "@types/proper-lockfile": "^4.1.4",
     "@vue/language-core": "~3.3.0",

--- a/packages/vite-plugin-checker/src/checkers/biome/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/biome/main.ts
@@ -23,6 +23,7 @@ import {
   createLintScheduler,
   DEFAULT_DEBOUNCE_MS,
 } from '../_shared/lintScheduler.js'
+import { parseArgsStringToArgv } from '../stylelint/argv.js'
 import { getBiomeCommand, runBiome, severityMap } from './cli.js'
 
 const __filename = fileURLToPath(import.meta.url)
@@ -163,7 +164,15 @@ export class BiomeChecker extends Checker<'biome'> {
         buildBin: (pluginConfig) => {
           if (typeof pluginConfig.biome === 'object') {
             const { command, flags } = pluginConfig.biome
-            return ['biome', [command || 'check', flags || ''] as const]
+            // `flags` holds several flags in one string, and the command is
+            // spawned as a list, so split it the way a shell would.
+            return [
+              'biome',
+              [
+                command || 'check',
+                ...(flags ? parseArgsStringToArgv(flags) : []),
+              ],
+            ] as const
           }
           return ['biome', ['check']]
         },

--- a/packages/vite-plugin-checker/src/checkers/eslint/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/eslint/main.ts
@@ -37,6 +37,7 @@ const manager = new FileDiagnosticManager()
 let createServeAndBuild: any
 
 import type { CreateDiagnostic } from '../../types'
+import { parseArgsStringToArgv } from '../stylelint/argv.js'
 
 /**
  * Detect the installed ESLint major version.
@@ -258,9 +259,11 @@ export class EslintChecker extends Checker<'eslint'> {
         buildBin: (pluginConfig) => {
           if (pluginConfig.eslint) {
             const { lintCommand } = pluginConfig.eslint
-            return ['eslint', lintCommand.split(' ').slice(1)]
+            // The command is spawned as a list of arguments, so split it the
+            // way a shell would and keep a quoted argument whole.
+            return ['eslint', parseArgsStringToArgv(lintCommand).slice(1)]
           }
-          return ['eslint', ['']]
+          return ['eslint', []]
         },
       },
       createDiagnostic,

--- a/packages/vite-plugin-checker/src/checkers/stylelint/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/stylelint/main.ts
@@ -28,6 +28,7 @@ const manager = new FileDiagnosticManager()
 let createServeAndBuild: any
 
 import type { CreateDiagnostic } from '../../types.js'
+import { parseArgsStringToArgv } from './argv.js'
 
 const __filename = fileURLToPath(import.meta.url)
 
@@ -162,9 +163,11 @@ export class StylelintChecker extends Checker<'stylelint'> {
         buildBin: (pluginConfig) => {
           if (pluginConfig.stylelint) {
             const { lintCommand } = pluginConfig.stylelint
-            return ['stylelint', lintCommand.split(' ').slice(1)]
+            // The command is spawned as a list of arguments, so split it the
+            // way a shell would and keep a quoted argument whole.
+            return ['stylelint', parseArgsStringToArgv(lintCommand).slice(1)]
           }
-          return ['stylelint', ['']]
+          return ['stylelint', []]
         },
       },
       createDiagnostic,

--- a/packages/vite-plugin-checker/src/checkers/typescript/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/typescript/main.ts
@@ -71,7 +71,7 @@ const createDiagnostic: CreateDiagnostic<'typescript'> = (pluginConfig) => {
       const isTsV7 = !ts.sys
 
       if (isTsV7) {
-        const { spawn } = await import('node:child_process')
+        const { default: spawn } = await import('cross-spawn')
         const { existsSync, readFileSync } = await import('node:fs')
         const { createRequire } = await import('node:module')
         const { stripVTControlCharacters: strip } = await import('node:util')
@@ -124,6 +124,7 @@ const createDiagnostic: CreateDiagnostic<'typescript'> = (pluginConfig) => {
         // notices) so they don't get surfaced as checker diagnostics; tsc
         // reports through stdout, stderr is reserved for real failures.
         const tscEnv = { ...process.env, NODE_NO_WARNINGS: '1' }
+        // No shell either way, so a path containing a space stays one argument.
         const tscProcess = runWithNode
           ? spawn(process.execPath, [tscBin, ...args], {
               cwd: finalConfig.root,
@@ -132,7 +133,6 @@ const createDiagnostic: CreateDiagnostic<'typescript'> = (pluginConfig) => {
           : spawn(tscBin, args, {
               cwd: finalConfig.root,
               env: tscEnv,
-              shell: true,
             })
 
         let logChunk = ''
@@ -246,6 +246,13 @@ const createDiagnostic: CreateDiagnostic<'typescript'> = (pluginConfig) => {
             pendingDiag.message += os.EOL + line
           }
         }
+
+        // The streams are typed as nullable because stdio can be configured
+        // away; the spawn above leaves it at the default, so they are there.
+        invariant(
+          tscProcess.stdout && tscProcess.stderr,
+          'tsc was spawned without pipes for its output',
+        )
 
         tscProcess.stdout.on('data', (chunk: Buffer) => {
           stdoutBuffer += chunk.toString()

--- a/packages/vite-plugin-checker/src/main.ts
+++ b/packages/vite-plugin-checker/src/main.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process'
+import spawn from 'cross-spawn'
 import { npmRunPathEnv, type ProcessEnv } from 'npm-run-path'
 import colors from 'picocolors'
 
@@ -249,19 +249,17 @@ function spawnChecker(
       typeof buildBin === 'function' ? buildBin(userConfig) : buildBin
 
     const [command, args] = finalBin
-    const commandWithArgs = [command, ...args].join(' ')
 
-    const proc = spawn(commandWithArgs, {
+    // No shell: the arguments are handed to the checker as a list, so nothing
+    // has to be escaped and an argument containing a space (a project path,
+    // say) cannot fall apart into two. cross-spawn is what makes that possible
+    // on Windows, where the binaries in node_modules/.bin are .cmd shims that
+    // Node refuses to run without a shell; it resolves the shim and quotes the
+    // arguments for cmd.exe itself.
+    const proc = spawn(command, [...args], {
       cwd: process.cwd(),
       stdio: 'inherit',
       env: localEnv,
-      // shell is necessary on windows to get the process to even start.
-      // Command line args constructed by checkers therefore need to escape double quotes
-      // to have them not striped out by cmd.exe. Using shell on all platforms lets us avoid
-      // having to perform platform-specific logic around escaping quotes since all platform
-      // shells will strip out unescaped double quotes. E.g. shell=false on linux only would
-      // result in escaped quotes not being unescaped.
-      shell: true,
     })
 
     proc.on('exit', (code) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0
+      cross-spawn:
+        specifier: ^7.0.6
+        version: 7.0.6
       npm-run-path:
         specifier: ^6.0.0
         version: 6.0.0
@@ -117,6 +120,9 @@ importers:
         specifier: ^1.3.3
         version: 1.3.3
     devDependencies:
+      '@types/cross-spawn':
+        specifier: ^6.0.6
+        version: 6.0.6
       '@types/picomatch':
         specifier: ^4.0.3
         version: 4.0.3
@@ -1864,6 +1870,9 @@ packages:
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/cross-spawn@6.0.6':
+    resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -4915,6 +4924,10 @@ snapshots:
       assertion-error: 2.0.1
 
   '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 20.19.9
+
+  '@types/cross-spawn@6.0.6':
     dependencies:
       '@types/node': 20.19.9
 


### PR DESCRIPTION
The build command was assembled into one string and handed to a shell, which splits it on whitespace. Anything the checkers built that could contain a space therefore fell apart: a project under a directory with a space in its name reached tsc as two arguments and failed with "TS5042: Option 'project' cannot be mixed with source files on a command line". Node concatenates args under `shell: true` without escaping them, and deprecates the combination for this reason (DEP0190).

Spawn the binaries through cross-spawn with the arguments as a list and no shell, so nothing needs escaping. cross-spawn is what makes that work on Windows, where the binaries in node_modules/.bin are .cmd shims that Node refuses to run without a shell.

The arguments now have to arrive already separated, since no shell is left to do it: the eslint and stylelint commands and biome's flags are split with the same quote aware parser the oxlint checker already uses, so a quoted argument stays whole and loses its quotes exactly as before. The empty string that used to be passed when there is no lint command is gone too; a shell dropped it, a list would not.

One behaviour change comes with this: an unquoted glob in a lint command is no longer expanded by the shell before the linter sees it. Both eslint and stylelint expand globs themselves, and cmd.exe never expanded them, so this makes the platforms agree.