### PR TITLE
fix(typescript): print a repeated report only once

### DIFF
--- a/packages/vite-plugin-checker/src/checkers/typescript/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/typescript/main.ts
@@ -136,6 +136,7 @@ const createDiagnostic: CreateDiagnostic<'typescript'> = (pluginConfig) => {
             })
 
         let logChunk = ''
+        let prevReport = ''
 
         // Buffer partial lines across `data` chunks; tsc may split a line
         // (or a multi-line diagnostic) across chunk boundaries.
@@ -220,19 +221,22 @@ const createDiagnostic: CreateDiagnostic<'typescript'> = (pluginConfig) => {
             ensureCall(() => {
               if (terminal) {
                 const color = errorCount > 0 ? 'red' : 'green'
-                consoleLog(
-                  colors[color](
-                    (errorCount > 0 ? capturedLogChunk : '') +
-                      os.EOL +
-                      wrapCheckerSummary(
-                        'TypeScript',
-                        errorCount > 0
-                          ? `Found ${errorCount} error(s)`
-                          : 'No errors',
-                      ),
-                  ),
-                  errorCount > 0 ? 'error' : 'info',
+                const report = colors[color](
+                  (errorCount > 0 ? capturedLogChunk : '') +
+                    os.EOL +
+                    wrapCheckerSummary(
+                      'TypeScript',
+                      errorCount > 0
+                        ? `Found ${errorCount} error(s)`
+                        : 'No errors',
+                    ),
                 )
+                // One edit can reach the watcher as several events, and tsc
+                // then compiles and reports again with the same result. Print
+                // a report that repeats the last one once, as vue-tsc does.
+                if (report === prevReport) return
+                prevReport = report
+                consoleLog(report, errorCount > 0 ? 'error' : 'info')
               }
             })
             logChunk = ''

--- a/packages/vite-plugin-checker/src/checkers/typescript/main.ts
+++ b/packages/vite-plugin-checker/src/checkers/typescript/main.ts
@@ -232,8 +232,7 @@ const createDiagnostic: CreateDiagnostic<'typescript'> = (pluginConfig) => {
                     ),
                 )
                 // One edit can reach the watcher as several events, and tsc
-                // then compiles and reports again with the same result. Print
-                // a report that repeats the last one once, as vue-tsc does.
+                // then compiles and reports again with the same result.
                 if (report === prevReport) return
                 prevReport = report
                 consoleLog(report, errorCount > 0 ? 'error' : 'info')
@@ -291,6 +290,7 @@ const createDiagnostic: CreateDiagnostic<'typescript'> = (pluginConfig) => {
       }
 
       let logChunk = ''
+      let prevReport = ''
 
       // https://github.com/microsoft/TypeScript/blob/a545ab1ac2cb24ff3b1aaf0bfbfb62c499742ac2/src/compiler/watch.ts#L12-L28
       const reportDiagnostic = (diagnostic: typescript.Diagnostic) => {
@@ -339,17 +339,17 @@ const createDiagnostic: CreateDiagnostic<'typescript'> = (pluginConfig) => {
 
           if (terminal) {
             const color = errorCount && errorCount > 0 ? 'red' : 'green'
-            consoleLog(
-              colors[color](
-                logChunk +
-                  os.EOL +
-                  wrapCheckerSummary(
-                    'TypeScript',
-                    diagnostic.messageText.toString(),
-                  ),
-              ),
-              errorCount ? 'error' : 'info',
+            const report = colors[color](
+              logChunk +
+                os.EOL +
+                wrapCheckerSummary(
+                  'TypeScript',
+                  diagnostic.messageText.toString(),
+                ),
             )
+            if (report === prevReport) return
+            prevReport = report
+            consoleLog(report, errorCount ? 'error' : 'info')
           }
         })
       }


### PR DESCRIPTION
One edit can reach the watcher as several events, so tsc compiles again and reports the same diagnostics, and the terminal shows the same block twice. It also makes the typescript-7 playground test fail on Windows, where the extra event is common: the test snapshots every report the checker makes.

Keep the last report and skip printing one that repeats it, the way the vue-tsc checker already does. The overlay is still updated on every compile, since it carries state rather than a log.