### PR TITLE
fix(build): run build-mode checkers from the resolved Vite root

### DIFF
--- a/packages/vite-plugin-checker/__tests__/spawnChecker.spec.ts
+++ b/packages/vite-plugin-checker/__tests__/spawnChecker.spec.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { spawnChecker } from '../src/main'
+import type { ServeAndBuildChecker } from '../src/types'
+
+// `vi.mock` is hoisted above the import, so `spawn` is stubbed before main loads.
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }))
+
+vi.mock('node:child_process', () => ({ spawn: spawnMock }))
+
+beforeEach(() => {
+  spawnMock.mockReset()
+  spawnMock.mockReturnValue({
+    on: (event: string, cb: (code: number) => void) => {
+      if (event === 'exit') cb(0)
+    },
+  })
+})
+
+const makeChecker = (buildBin: ServeAndBuildChecker['build']['buildBin']) =>
+  ({ build: { buildBin } }) as ServeAndBuildChecker
+
+describe('spawnChecker', () => {
+  it('runs the build command from the provided cwd', async () => {
+    await spawnChecker(
+      makeChecker(['tsc', ['--noEmit']]),
+      {},
+      {},
+      '/monorepo/packages/app',
+    )
+
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+    expect(spawnMock).toHaveBeenCalledWith(
+      'tsc --noEmit',
+      expect.objectContaining({ cwd: '/monorepo/packages/app' }),
+    )
+  })
+
+  it('resolves a function buildBin against userConfig', async () => {
+    await spawnChecker(
+      makeChecker((config) => ['eslint', [config.root ?? '.']]),
+      { root: '/monorepo' },
+      {},
+      '/monorepo',
+    )
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'eslint /monorepo',
+      expect.objectContaining({ cwd: '/monorepo' }),
+    )
+  })
+})

--- a/packages/vite-plugin-checker/src/main.ts
+++ b/packages/vite-plugin-checker/src/main.ts
@@ -68,6 +68,9 @@ export function checker(userConfig: UserPluginConfig): Plugin {
   let buildWatch = false
   let logger: Logger | null = null
   let checkerPromise: Promise<void> | null = null
+  // Vite's resolved root, captured in `configResolved`. Build-mode checkers use
+  // this (like serve mode does) so spawned commands run from the same cwd.
+  let resolvedRoot = process.cwd()
 
   return {
     name: 'vite-plugin-checker',
@@ -105,6 +108,7 @@ export function checker(userConfig: UserPluginConfig): Plugin {
         : config.base
       isProduction ||= config.isProduction || config.command === 'build'
       buildWatch = !!config.build.watch
+      resolvedRoot = config.root
     },
     async buildEnd() {
       if (viteMode !== 'serve') {
@@ -163,14 +167,18 @@ export function checker(userConfig: UserPluginConfig): Plugin {
       // run a bin command in a separated process
       if (!isProduction || !enableBuild) return
 
+      // Mirror serve mode (see `configureServer`): run build commands from the
+      // resolved Vite root, falling back to an explicit `root` option, so
+      // checkers behave consistently in monorepos instead of using process.cwd().
+      const root = userConfig.root || resolvedRoot
       const localEnv = npmRunPathEnv({
         env: process.env,
-        cwd: process.cwd(),
+        cwd: root,
         execPath: process.execPath,
       })
 
       const spawnedCheckers = checkers.map((checker) =>
-        spawnChecker(checker, userConfig, localEnv),
+        spawnChecker(checker, userConfig, localEnv, root),
       )
 
       // wait for checker states while avoiding blocking the build from continuing in parallel
@@ -238,10 +246,11 @@ export function checker(userConfig: UserPluginConfig): Plugin {
   }
 }
 
-function spawnChecker(
+export function spawnChecker(
   checker: ServeAndBuildChecker,
   userConfig: Partial<PluginConfig>,
   localEnv: ProcessEnv,
+  cwd: string,
 ) {
   return new Promise<number>((resolve) => {
     const buildBin = checker.build.buildBin
@@ -252,7 +261,7 @@ function spawnChecker(
     const commandWithArgs = [command, ...args].join(' ')
 
     const proc = spawn(commandWithArgs, {
-      cwd: process.cwd(),
+      cwd,
       stdio: 'inherit',
       env: localEnv,
       // shell is necessary on windows to get the process to even start.


### PR DESCRIPTION
Closes #631

### Problem

Checker commands run from a different working directory in serve vs build mode:

- **Serve** (`configureServer`): `cwd` is `userConfig.root || server.config.root`.
- **Build** (`spawnChecker`): `cwd` was `process.cwd()`.

For `lintCommand`-based checkers (eslint, oxlint) this is inconsistent in monorepos where Vite's `root` differs from the current working directory: the same lint command resolves configs/paths differently between `vite` and `vite build`.

### Fix

Capture the resolved root in `configResolved` and use `userConfig.root || resolvedRoot` as the `cwd` for the spawned build commands (and their `npm-run-path` env), matching serve mode.

This is a **no-op when `root` already equals `process.cwd()`** (the common case, and what the e2e playground harness exercises, since it runs `vite build` with `cwd` set to the project root). Behavior only changes in the monorepo case the issue describes.

### Tests

Added `__tests__/spawnChecker.spec.ts` asserting the build command spawns with the provided `cwd`. `spawnChecker` is exported so it can be unit-tested in isolation. Full unit project passes (43 tests), `tsc --noEmit` and biome are clean.

*Written with AI assistance; I've reviewed and tested the change and will maintain it.*
