### PR TITLE
fix(biome): preserve Windows diagnostic paths

### DIFF
--- a/packages/vite-plugin-checker/__tests__/biomeCli.spec.ts
+++ b/packages/vite-plugin-checker/__tests__/biomeCli.spec.ts
@@ -1,0 +1,322 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  parseBiomeOutput,
+  sanitizeBiomeOutput,
+} from '../src/checkers/biome/cli'
+import { normalizePath } from '../src/sources'
+
+const source = 'const value = 1\n'
+
+function modernDiagnostic(file: string, message = 'diagnostic message') {
+  return {
+    severity: 'error',
+    message,
+    category: 'lint/test',
+    location: {
+      path: file,
+      start: { line: 1, column: 1 },
+      end: { line: 1, column: 6 },
+    },
+    advices: [],
+  }
+}
+
+function biomeOutputWithRawPaths(
+  diagnostics: Record<string, unknown>[],
+  paths: string[],
+) {
+  let output = JSON.stringify({ diagnostics })
+
+  for (const [index, file] of paths.entries()) {
+    output = output.replace(
+      JSON.stringify(`__RAW_PATH_${index}__`),
+      `"${file}"`,
+    )
+  }
+
+  return output
+}
+
+describe('Biome Windows paths', () => {
+  let cwd: string
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'vite-plugin-checker-biome-'))
+  })
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true })
+  })
+
+  async function writeModernSource(file: string) {
+    const normalized = normalizePath(file, cwd)
+    await mkdir(dirname(normalized), { recursive: true })
+    await writeFile(normalized, source)
+    return normalized
+  }
+
+  it.each([
+    String.raw`src\util.ts`,
+    String.raw`src\test.ts`,
+    String.raw`src\new.ts`,
+    String.raw`src\routes.ts`,
+    String.raw`src\button.ts`,
+    String.raw`src\form.ts`,
+  ])('keeps a raw Windows path literal: %s', async (file) => {
+    const normalized = await writeModernSource(file)
+    const output = biomeOutputWithRawPaths(
+      [modernDiagnostic('__RAW_PATH_0__')],
+      [file],
+    )
+
+    const diagnostics = await parseBiomeOutput(output, cwd)
+
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0]?.id).toBe(normalized)
+  })
+
+  it('keeps a raw drive path literal', async () => {
+    const file =
+      process.platform === 'win32'
+        ? join(cwd, 'src', 'drive.ts')
+        : String.raw`C:\src\drive.ts`
+    const normalized = await writeModernSource(file)
+    const output = biomeOutputWithRawPaths(
+      [modernDiagnostic('__RAW_PATH_0__')],
+      [file],
+    )
+
+    const diagnostics = await parseBiomeOutput(output, cwd)
+
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0]?.id).toBe(normalized)
+  })
+
+  it('repairs a reordered modern location', async () => {
+    const file = String.raw`src\util\test.ts`
+    const normalized = await writeModernSource(file)
+    const output = biomeOutputWithRawPaths(
+      [
+        {
+          severity: 'error',
+          message: 'diagnostic message',
+          category: 'lint/test',
+          location: {
+            start: { line: 1, column: 1 },
+            path: '__RAW_PATH_0__',
+            end: { line: 1, column: 6 },
+          },
+          advices: [],
+        },
+      ],
+      [file],
+    )
+
+    const diagnostics = await parseBiomeOutput(output, cwd)
+
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0]?.id).toBe(normalized)
+  })
+
+  it('keeps a raw UNC path literal', () => {
+    const file = String.raw`\\server\share\util.ts`
+    const output = biomeOutputWithRawPaths(
+      [modernDiagnostic('__RAW_PATH_0__')],
+      [file],
+    )
+
+    const parsed = JSON.parse(sanitizeBiomeOutput(output))
+
+    expect(parsed.diagnostics[0].location.path).toBe(file)
+  })
+
+  it('does not change correctly escaped Windows paths', () => {
+    const drive = String.raw`C:\src\util.ts`
+    const unc = String.raw`\\server\share\util.ts`
+    const rootRelative = String.raw`\src\util.ts`
+    const output = JSON.stringify({
+      diagnostics: [
+        modernDiagnostic(drive),
+        modernDiagnostic(unc),
+        modernDiagnostic(rootRelative),
+      ],
+    })
+
+    const sanitized = sanitizeBiomeOutput(output)
+
+    expect(sanitized).toBe(output)
+    const parsed = JSON.parse(sanitized) as {
+      diagnostics: { location: { path: string } }[]
+    }
+    expect(parsed.diagnostics.map((item) => item.location.path)).toEqual([
+      drive,
+      unc,
+      rootRelative,
+    ])
+  })
+
+  it('repairs every raw path in an output with multiple diagnostics', async () => {
+    const files = [String.raw`src\util.ts`, String.raw`test\button.ts`]
+    const normalized = await Promise.all(files.map(writeModernSource))
+    const output = biomeOutputWithRawPaths(
+      files.map((_, index) => modernDiagnostic(`__RAW_PATH_${index}__`)),
+      files,
+    )
+
+    const diagnostics = await parseBiomeOutput(output, cwd)
+
+    expect(diagnostics.map((item) => item.id)).toEqual(normalized)
+  })
+
+  it('repairs a raw legacy object path', async () => {
+    const file = String.raw`src\util\test.ts`
+    const output = biomeOutputWithRawPaths(
+      [
+        {
+          severity: 'error',
+          description: 'legacy diagnostic',
+          category: 'lint/test',
+          location: {
+            path: { file: '__RAW_PATH_0__' },
+            sourceCode: source,
+            span: [0, 5],
+          },
+        },
+      ],
+      [file],
+    )
+
+    const diagnostics = await parseBiomeOutput(output, cwd)
+
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0]?.id).toBe(normalizePath(file, cwd))
+  })
+
+  it('repairs a reordered legacy path object', async () => {
+    const file = String.raw`src\util\test.ts`
+    const output = biomeOutputWithRawPaths(
+      [
+        {
+          severity: 'error',
+          description: 'legacy diagnostic',
+          category: 'lint/test',
+          location: {
+            path: { kind: 'file', file: '__RAW_PATH_0__' },
+            sourceCode: source,
+            span: [0, 5],
+          },
+        },
+      ],
+      [file],
+    )
+
+    const diagnostics = await parseBiomeOutput(output, cwd)
+
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0]?.id).toBe(normalizePath(file, cwd))
+  })
+
+  it('does not sanitize location paths outside direct diagnostic locations', () => {
+    const paths = [String.raw`metadata\util.ts`, String.raw`advice\test.ts`]
+    const output = biomeOutputWithRawPaths(
+      [
+        {
+          ...modernDiagnostic('src/util.ts'),
+          advices: [
+            {
+              location: { path: '__RAW_PATH_1__' },
+              text: 'nested advice',
+            },
+          ],
+        },
+      ],
+      [paths[0]!, paths[1]!],
+    ).replace(
+      '"diagnostics":',
+      `"metadata":{"location":{"path":"${paths[0]}"}},"diagnostics":`,
+    )
+
+    expect(sanitizeBiomeOutput(output)).toBe(output)
+  })
+
+  it('preserves legal JSON escapes in a path', () => {
+    const output = String.raw`{"diagnostics":[{"severity":"error","message":"diagnostic message","category":"lint/test","location":{"path":"src\/caf\u00e9\"quote.ts","start":{"line":1,"column":1},"end":{"line":1,"column":6}},"advices":[]}]}`
+
+    expect(sanitizeBiomeOutput(output)).toBe(output)
+    expect(JSON.parse(output).diagnostics[0].location.path).toBe(
+      'src/café"quote.ts',
+    )
+  })
+
+  it('uses a raw unicode-looking path when only that source exists', async () => {
+    const rawFile = String.raw`src\u1234.ts`
+    const normalized = await writeModernSource(rawFile)
+    const output = biomeOutputWithRawPaths(
+      [modernDiagnostic('__RAW_PATH_0__')],
+      [rawFile],
+    )
+
+    expect(sanitizeBiomeOutput(output)).toBe(output)
+    const diagnostics = await parseBiomeOutput(output, cwd)
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0]?.id).toBe(normalized)
+  })
+
+  it('uses standard JSON unicode semantics when that source exists', async () => {
+    const rawFile = String.raw`src\u1234.ts`
+    const unicodeFile = 'src\u1234.ts'
+    const normalized = await writeModernSource(unicodeFile)
+    const output = biomeOutputWithRawPaths(
+      [modernDiagnostic('__RAW_PATH_0__')],
+      [rawFile],
+    )
+
+    expect(sanitizeBiomeOutput(output)).toBe(output)
+    const diagnostics = await parseBiomeOutput(output, cwd)
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0]?.id).toBe(normalized)
+  })
+
+  it('prefers standard JSON unicode semantics when both sources exist', async () => {
+    const rawFile = String.raw`src\u1234.ts`
+    const unicodeFile = 'src\u1234.ts'
+    await writeModernSource(rawFile)
+    const normalized = await writeModernSource(unicodeFile)
+    const output = biomeOutputWithRawPaths(
+      [modernDiagnostic('__RAW_PATH_0__')],
+      [rawFile],
+    )
+
+    const diagnostics = await parseBiomeOutput(output, cwd)
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0]?.id).toBe(normalized)
+  })
+
+  it('leaves Unix paths unchanged', async () => {
+    const file = 'src/util.ts'
+    const normalized = await writeModernSource(file)
+    const output = JSON.stringify({ diagnostics: [modernDiagnostic(file)] })
+
+    expect(sanitizeBiomeOutput(output)).toBe(output)
+    const diagnostics = await parseBiomeOutput(output, cwd)
+    expect(diagnostics[0]?.id).toBe(normalized)
+  })
+
+  it('does not change unrelated JSON strings', async () => {
+    const file = String.raw`src\util.ts`
+    await writeModernSource(file)
+    const message = 'first line\nC:\\docs\\readme.md says "hello"'
+    const output = JSON.stringify({
+      diagnostics: [modernDiagnostic(file, message)],
+      summary: String.raw`C:\reports\summary.txt`,
+    })
+
+    expect(sanitizeBiomeOutput(output)).toBe(output)
+    const diagnostics = await parseBiomeOutput(output, cwd)
+    expect(diagnostics[0]?.message).toBe(`[lint/test] ${message}`)
+  })
+})

--- a/packages/vite-plugin-checker/src/checkers/biome/cli.ts
+++ b/packages/vite-plugin-checker/src/checkers/biome/cli.ts
@@ -63,6 +63,8 @@ export function runBiome(argv: string[], cwd: string) {
 }
 
 type Entry = {
+  diagnosticIndex: number
+  isModern: boolean
   file: string
   message: string
   category: string
@@ -87,12 +89,14 @@ function isLegacyDiagnostic(d: Diagnostic): d is LegacyDiagnostic {
 }
 
 function getEntries(parsed: BiomeOutput, cwd: string): Entry[] {
-  return parsed.diagnostics.flatMap((d): Entry[] => {
+  return parsed.diagnostics.flatMap((d, diagnosticIndex): Entry[] => {
     if (!d.location) return []
 
     if (isModernDiagnostic(d)) {
       return [
         {
+          diagnosticIndex,
+          isModern: true,
           file: normalizePath(d.location.path, cwd),
           message: d.message,
           category: d.category ?? '',
@@ -107,6 +111,8 @@ function getEntries(parsed: BiomeOutput, cwd: string): Entry[] {
       const file = d.location.path?.file ?? ''
       return [
         {
+          diagnosticIndex,
+          isModern: false,
           file: normalizePath(file, cwd),
           message: d.description,
           category: d.category ?? '',
@@ -159,9 +165,162 @@ function buildDiagnostics(
   })
 }
 
-function sanitizeBiomeOutput(output: string) {
-  // Biome on Windows emits unescaped backslashes in JSON path values
-  return output.replace(/\\(?!["\\/bfnrtu])/g, '\\\\')
+function sanitizeBiomeOutputCandidate(
+  output: string,
+  unicodeEscapesAreRaw: boolean,
+) {
+  type Context =
+    | 'root'
+    | 'diagnostics'
+    | 'diagnostic'
+    | 'location'
+    | 'path'
+    | 'pathObject'
+    | 'targetPath'
+    | 'other'
+
+  const replacements: { start: number; end: number; value: string }[] = []
+  const skipWhitespace = (index: number) => {
+    let cursor = index
+    while (/\s/.test(output[cursor] ?? '')) cursor++
+    return cursor
+  }
+  const scanString = (start: number) => {
+    let index = start + 1
+    while (index < output.length) {
+      if (output[index] === '\\') {
+        index += 2
+      } else if (output[index] === '"') {
+        return index + 1
+      } else {
+        index++
+      }
+    }
+    return output.length
+  }
+  const readKey = (start: number, end: number) => {
+    try {
+      return JSON.parse(output.slice(start, end)) as string
+    } catch {
+      return ''
+    }
+  }
+  const hasRawBackslash = (path: string) => {
+    for (let index = 0; index < path.length; index++) {
+      if (path[index] !== '\\') continue
+
+      let runEnd = index
+      while (path[runEnd] === '\\') runEnd++
+      if ((runEnd - index) % 2 === 1) {
+        const escaped = path[runEnd]
+        const isUnicodeEscape =
+          !unicodeEscapesAreRaw &&
+          escaped === 'u' &&
+          /^[0-9a-f]{4}$/i.test(path.slice(runEnd + 1, runEnd + 5))
+        if (escaped !== '"' && escaped !== '/' && !isUnicodeEscape) {
+          return true
+        }
+      }
+      index = runEnd - 1
+    }
+    return false
+  }
+
+  const scanValue = (start: number, context: Context): number => {
+    const index = skipWhitespace(start)
+    const character = output[index]
+
+    if (character === '"') {
+      const end = scanString(index)
+      if (context === 'path' || context === 'targetPath') {
+        const path = output.slice(index + 1, end - 1)
+        if (hasRawBackslash(path)) {
+          replacements.push({
+            start: index + 1,
+            end: end - 1,
+            value: path.replaceAll('\\', '\\\\'),
+          })
+        }
+      }
+      return end
+    }
+
+    if (character === '{') {
+      const objectContext = context === 'path' ? 'pathObject' : context
+      let cursor = index + 1
+      while (cursor < output.length) {
+        cursor = skipWhitespace(cursor)
+        if (output[cursor] === '}') return cursor + 1
+        if (output[cursor] !== '"') return output.length
+
+        const keyStart = cursor
+        const keyEnd = scanString(keyStart)
+        const key = readKey(keyStart, keyEnd)
+        cursor = skipWhitespace(keyEnd)
+        if (output[cursor] !== ':') return output.length
+
+        let childContext: Context = 'other'
+        if (objectContext === 'root' && key === 'diagnostics') {
+          childContext = 'diagnostics'
+        } else if (objectContext === 'diagnostic' && key === 'location') {
+          childContext = 'location'
+        } else if (objectContext === 'location' && key === 'path') {
+          childContext = 'path'
+        } else if (objectContext === 'pathObject' && key === 'file') {
+          childContext = 'targetPath'
+        }
+
+        cursor = skipWhitespace(scanValue(cursor + 1, childContext))
+        if (output[cursor] === ',') {
+          cursor++
+        } else if (output[cursor] === '}') {
+          return cursor + 1
+        } else {
+          return output.length
+        }
+      }
+      return cursor
+    }
+
+    if (character === '[') {
+      const childContext = context === 'diagnostics' ? 'diagnostic' : 'other'
+      let cursor = index + 1
+      while (cursor < output.length) {
+        cursor = skipWhitespace(cursor)
+        if (output[cursor] === ']') return cursor + 1
+        cursor = skipWhitespace(scanValue(cursor, childContext))
+        if (output[cursor] === ',') {
+          cursor++
+        } else if (output[cursor] === ']') {
+          return cursor + 1
+        } else {
+          return output.length
+        }
+      }
+      return cursor
+    }
+
+    let end = index
+    while (end < output.length && !/[\s,}\]]/.test(output[end]!)) end++
+    return end
+  }
+
+  scanValue(0, 'root')
+
+  if (replacements.length === 0) return output
+
+  const chunks: string[] = []
+  let cursor = 0
+  for (const replacement of replacements) {
+    chunks.push(output.slice(cursor, replacement.start), replacement.value)
+    cursor = replacement.end
+  }
+  chunks.push(output.slice(cursor))
+  return chunks.join('')
+}
+
+export function sanitizeBiomeOutput(output: string) {
+  return sanitizeBiomeOutputCandidate(output, false)
 }
 
 /**
@@ -187,22 +346,58 @@ function getLineAndColumn(text?: string, offset?: number) {
   return { line, column }
 }
 
-async function parseBiomeOutput(
+export async function parseBiomeOutput(
   output: string,
   cwd: string,
 ): Promise<NormalizedDiagnostic[]> {
   let parsed: BiomeOutput
+  const sanitizedOutput = sanitizeBiomeOutput(output)
   try {
-    parsed = JSON.parse(sanitizeBiomeOutput(output))
+    parsed = JSON.parse(sanitizedOutput)
   } catch {
     return []
   }
 
   const entries = getEntries(parsed, cwd)
+  const unicodeRawOutput = sanitizeBiomeOutputCandidate(output, true)
+  let unicodeRawEntries: Entry[] = []
+  if (unicodeRawOutput !== sanitizedOutput) {
+    try {
+      unicodeRawEntries = getEntries(JSON.parse(unicodeRawOutput), cwd)
+    } catch {
+      // The standard JSON interpretation remains authoritative.
+    }
+  }
 
-  // Only read from disk for entries that don't have embedded source code.
-  const filesNeedingRead = getUniqueFiles(entries.filter((e) => !e.sourceCode))
+  const unicodeRawByDiagnostic = new Map(
+    unicodeRawEntries
+      .filter((entry) => entry.isModern)
+      .map((entry) => [entry.diagnosticIndex, entry]),
+  )
+  const entriesNeedingRead = entries.flatMap((entry): Entry[] => {
+    if (!entry.isModern) return entry.sourceCode ? [] : [entry]
+
+    const unicodeRaw = unicodeRawByDiagnostic.get(entry.diagnosticIndex)
+    return unicodeRaw && unicodeRaw.file !== entry.file
+      ? [entry, unicodeRaw]
+      : [entry]
+  })
+  const filesNeedingRead = getUniqueFiles(entriesNeedingRead)
   const sourceCache = await readSources(filesNeedingRead)
 
-  return buildDiagnostics(entries, sourceCache)
+  const resolvedEntries = entries.map((entry) => {
+    if (!entry.isModern) return entry
+
+    const unicodeRaw = unicodeRawByDiagnostic.get(entry.diagnosticIndex)
+    if (
+      unicodeRaw &&
+      !sourceCache.has(entry.file) &&
+      sourceCache.has(unicodeRaw.file)
+    ) {
+      return unicodeRaw
+    }
+    return entry
+  })
+
+  return buildDiagnostics(resolvedEntries, sourceCache)
 }


### PR DESCRIPTION
## Summary

- repair raw Windows backslashes only in Biome diagnostic path fields
- preserve already escaped paths and unrelated JSON values
- disambiguate valid Unicode escapes from raw path separators using the source files available to the checker
- add regression coverage for modern and legacy output, reordered fields, UNC paths, control escapes, multiple diagnostics, and Unicode ambiguity

Closes #737

## Testing

- `pnpm run build:test`
- `pnpm run test` (101 passed, 40 skipped)
- `pnpm run type-check`
- `pnpm run publint`
- `pnpm run test-knip`
- `pnpm exec biome check packages/vite-plugin-checker/src/checkers/biome/cli.ts packages/vite-plugin-checker/__tests__/biomeCli.spec.ts`
- `git diff --check`

The full browser suite was run in WSL with Playwright's Ubuntu 24.04 fallback build because Playwright 1.60.0 does not publish an Ubuntu 26.04 build.
